### PR TITLE
Automatically add coord bounds for image plotting.

### DIFF
--- a/geoviews/plotting/__init__.py
+++ b/geoviews/plotting/__init__.py
@@ -146,7 +146,12 @@ class GeoImagePlot(GeoPlot, ColorbarPlot):
     def get_data(self, element, ranges, style):
         self._norm_kwargs(element, ranges, style, element.vdims[0])
         style.pop('interpolation')
-        return (element.data.copy(),), style, {}
+        cube = element.data.copy()
+        # Make sure both coordinates have bounds to avoid iris warning.
+        for coord in cube.dim_coords:
+            if not coord.has_bounds():
+                coord.guess_bounds()
+        return (cube,), style, {}
 
     def init_artists(self, ax, plot_args, plot_kwargs):
         return {'artist': iplt.pcolormesh(*plot_args, axes=ax, **plot_kwargs)}

--- a/tests/testplotting.py
+++ b/tests/testplotting.py
@@ -1,0 +1,44 @@
+from iris.tests.stock import lat_lon_cube
+
+from geoviews.element import Image
+from geoviews.element.comparison import ComparisonTestCase
+from geoviews.plotting import GeoImagePlot
+
+
+class TestGeoImagePlot(ComparisonTestCase):
+    def test_auto_guess_bounds(self):
+        # Check that the `get_data()` method automatically adds bounds
+        # when they're missing.
+        cube = lat_lon_cube()
+        element = Image(cube.copy())
+        plot = GeoImagePlot(element)
+        ranges = {}
+        style = {'interpolation': None}
+        plot_args, style, axis_kwargs = plot.get_data(element, ranges, style)
+        for name in ('latitude', 'longitude'):
+            cube.coord(name).guess_bounds()
+        self.assertEqual(plot_args, (cube,))
+        self.assertEqual(style, {'vmax': 11, 'vmin': 0})
+        self.assertEqual(axis_kwargs, {})
+
+    def test_auto_guess_bounds_not_needed(self):
+        # Check that the `get_data()` method *doesn't* try to add or
+        # modify the bounds when they're already present.
+        cube = lat_lon_cube()
+        for name in ('latitude', 'longitude'):
+            coord = cube.coord(name)
+            coord.guess_bounds()
+            coord.bounds = coord.bounds + 0.1
+        element = Image(cube.copy())
+        plot = GeoImagePlot(element)
+        ranges = {}
+        style = {'interpolation': None}
+        plot_args, style, axis_kwargs = plot.get_data(element, ranges, style)
+        self.assertEqual(plot_args, (cube,))
+        self.assertEqual(style, {'vmax': 11, 'vmin': 0})
+        self.assertEqual(axis_kwargs, {})
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
Closes CubeBrowser/cube-explorer#63.