### PR TITLE
Minor fixes for the Introductory Tutorial

### DIFF
--- a/doc/Introductory_Tutorial.ipynb
+++ b/doc/Introductory_Tutorial.ipynb
@@ -256,7 +256,7 @@
     "%%opts Layout [fig_inches=(12,7)] Curve [aspect=2 xticks=4 xrotation=20] Points (color=2) Overlay [aspect='equal']\n",
     "%%opts Image [projection=crs.PlateCarree()]\n",
     "# Sample the surface_temperature at (0,10)\n",
-    "temp_curve = surface_temperature.to.curve('time', dynamic=True)[0, 10]\n",
+    "temp_curve = hv.Curve(surface_temperature.select(latitude=0, longitude=0), kdims=['time'])\n",
     "# Show surface_temperature and air_temperature with Point (0,10) marked\n",
     "temp_maps = [cb.to.image(['longitude', 'latitude']) * gv.Points([(0,10)]) \n",
     "             for cb in [surface_temperature, air_temperature]]\n",
@@ -276,17 +276,6 @@
    "metadata": {},
    "source": [
     "Lets view the surface temperatures together with the global coastline:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "cf.COASTLINE.scale='1000m'"
    ]
   },
   {


### PR DESCRIPTION
Small changes for the Introductory Tutorial, demonstrating select instead of creating a DynamicMap to sample. Additionally removed coastline scale as '1000m' is not a valid scale and the correct way to set the scale is via a plot option.