### PR TITLE
Fixed outdated reference to holocube in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - python setup.py install
 
 script:
-  - nosetests --with-doctest --with-coverage --cover-package=holocube
+  - nosetests --with-doctest --with-coverage --cover-package=geoviews
   - flake8 --ignore=E,W . --exclude=./doc
 
 after_success: coveralls


### PR DESCRIPTION
As the title says the coverage report should be referencing the geoviews package not holocube.