### PR TITLE
Updated references to holocube in docs

### DIFF
--- a/doc/Homepage.ipynb
+++ b/doc/Homepage.ipynb
@@ -81,7 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts GeoImage [colorbar=True] (cmap='viridis')\n",
+    "%%opts Image [colorbar=True] (cmap='viridis') Overlay [fig_size=200]\n",
     "(hv.Dataset(surface_temp).groupby(['time'], group_type=gv.Image) * gv.Feature(cf.COASTLINE))"
    ]
   }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,10 +9,10 @@ paths = ['../param/', '.', '..']
 add_paths(paths)
 
 # # General information about the project.
-project = u'HoloCube'
-copyright = u'2016, HoloCube developers'
-authors = u'HoloCube developers'
-module = 'holocube'
+project = u'GeoViews'
+copyright = u'2016, GeoViews developers'
+authors = u'GeoViews developers'
+module = 'geoviews'
 description = 'Browser based exploration of Iris cubes'
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,4 +1,4 @@
-.. HoloCube documentation master file
+.. GeoViews documentation master file
 
 .. raw:: html
   :file: latest_news.html
@@ -6,7 +6,7 @@
 Introduction
 ____________
 
-.. notebook:: holocube Homepage.ipynb
+.. notebook:: geoviews Homepage.ipynb
 
 ------------
 
@@ -16,7 +16,7 @@ is to come in our `first tutorial <Introductory_Tutorial.html>`_.
 Installation
 ____________
 
-See the `github repo <https://github.com/CubeBrowser/cube-explorer>`_
+See the `github repo <https://github.com/ioam/geoviews>`_
 for installation instructions and to get started with the examples.
 
 ------------
@@ -24,13 +24,13 @@ for installation instructions and to get started with the examples.
 Support
 _______
 
-HoloCube was developed through a collaboration between
+GeoViews was developed through a collaboration between
 `Continuum Analytics <https://continuum.io>`_ and the `UK Metropolitan Office
-<http://www.metoffice.gov.uk>`_.  HoloCube is completely `open source
-<https://github.com/ioam/holoviews>`_, available under a BSD license
+<http://www.metoffice.gov.uk>`_.  GeoViews is completely `open source
+<https://github.com/ioam/geoviews>`_, available under a BSD license
 freely for both commercial and non-commercial use.  Please file
 bug reports and feature requests on our
-`github site <https://github.com/ioam/holoviews/issues>`_.
+`github site <https://github.com/ioam/geoviews/issues>`_.
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
Small PR to replace references to holocube in docs, using geoviews instead. Also includes small fix for Homepage example notebook.