### PR TITLE
Improved support for geographic plot aspects and extents

### DIFF
--- a/doc/Introductory_Tutorial.ipynb
+++ b/doc/Introductory_Tutorial.ipynb
@@ -232,8 +232,9 @@
    },
    "outputs": [],
    "source": [
-    "surface_temperature.to.image(['longitude', 'latitude']) + \\\n",
-    "    air_temperature.to.image(['longitude', 'latitude'])(plot=dict(projection=crs.PlateCarree()))"
+    "%%opts Layout [fig_inches=(12,4)]\n",
+    "(surface_temperature.to.image(['longitude', 'latitude'])+\n",
+    " air_temperature.to.image(['longitude', 'latitude'])(plot=dict(projection=crs.PlateCarree())))"
    ]
   },
   {
@@ -254,7 +255,7 @@
    "outputs": [],
    "source": [
     "%%opts Layout [fig_inches=(12,7)] Curve [aspect=2 xticks=4 xrotation=20] Points (color=2)\n",
-    "%%opts Overlay [aspect='equal'] Image [projection=crs.PlateCarree()]\n",
+    "%%opts Image [projection=crs.PlateCarree()]\n",
     "\n",
     "temp_curve = hv.Curve(surface_temperature.select(longitude=0, latitude=10), kdims=['time'])\n",
     "\n",

--- a/geoviews/element/__init__.py
+++ b/geoviews/element/__init__.py
@@ -1,24 +1,8 @@
-import iris
 from holoviews.core.data import Dataset
 from holoviews.element import ElementConversion, Points as HvPoints
 
-from .geo import (_Element, Feature, Tiles,     # noqa (API import)
+from .geo import (_Element, Feature, Tiles, is_geographic,     # noqa (API import)
                   WMTS, Points, Image, Text, LineContours, FilledContours)
-
-
-def is_geographic(dataset, kdims):
-    """
-    Small utility that determines whether the supplied dataset
-    and kdims represent a geographic coordinate system.
-    """
-
-    kdims = [dataset.get_dimension(d) for d in kdims]
-    if (len(kdims) == 2 and
-        ((isinstance(dataset, _Element) and kdims == dataset.kdims) or
-        (isinstance(dataset.data, iris.cube.Cube) and all(dataset.data.coord(
-            kd.name).coord_system for kd in kdims)))):
-        return True
-    return False
 
 
 class GeoConversion(ElementConversion):

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -10,24 +10,27 @@ from iris.cube import Cube
 
 geographic_types = (cGoogleTiles, cFeature)
 
-def is_geographic(dataset, kdims=None):
+def is_geographic(element, kdims=None):
     """
-    Small utility that determines whether the supplied dataset
-    and kdims represent a geographic coordinate system.
+    Utility to determine whether the supplied element optionally
+    a subset of its key dimensions represent a geographic coordinate
+    system.
     """
     if kdims:
-        kdims = [dataset.get_dimension(d) for d in kdims]
+        kdims = [element.get_dimension(d) for d in kdims]
     else:
-        kdims = dataset.kdims
+        kdims = element.kdims
 
-    if isinstance(dataset.data, geographic_types) or isinstance(dataset, WMTS):
+    if len(kdims) != 2:
+        return False
+    if isinstance(element.data, iris.cube.Cube):
+        return all(element.data.coord(kd.name).coord_system for kd in kdims)
+    elif isinstance(element.data, geographic_types) or isinstance(element, WMTS):
         return True
-    if (len(kdims) == 2 and
-        ((isinstance(dataset, _Element) and kdims == dataset.kdims) or
-        (isinstance(dataset.data, iris.cube.Cube) and all(dataset.data.coord(
-            kd.name).coord_system for kd in kdims)))):
-        return True
-    return False
+    elif isinstance(element, _Element):
+        return kdims == element.kdims and element.crs
+    else:
+        return False
 
 
 class _Element(Element2D):

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -46,6 +46,8 @@ class _Element(Element2D):
         coordinate system of the data. Inferred automatically
         when _Element wraps cartopy Feature object.""")
 
+    kdims = param.List(default=[Dimension('Longitude'), Dimension('Latitude')])
+
     def __init__(self, data, **kwargs):
         crs = None
         crs_data = data.data if isinstance(data, Dataset) else data
@@ -75,15 +77,27 @@ class _Element(Element2D):
                                            *args, **overrides)
 
 
-class Feature(_Element):
+class _GeoFeature(_Element):
+    """
+    Baseclass for geographic types without their own data.
+    """
+
+    _auxiliary_component = True
+
+    def dimension_values(self, dim):
+        """
+        _GeoFeature types do not contain actual data.
+        """
+        return []
+
+
+class Feature(_GeoFeature):
     """
     A Feature represents a geographical feature
     specified as a cartopy Feature type.
     """
 
     group = param.String(default='Feature')
-
-    _auxiliary_component = True
 
     def __init__(self, data, **params):
         if not isinstance(data, cFeature):
@@ -92,7 +106,7 @@ class Feature(_Element):
         super(Feature, self).__init__(data, **params)
 
 
-class WMTS(_Element):
+class WMTS(_GeoFeature):
     """
     The WMTS Element represents a Web Map Tile Service
     specified as a tuple of the API URL and
@@ -102,8 +116,6 @@ class WMTS(_Element):
 
     layer = param.String(doc="The layer on the tile service")
 
-    _auxiliary_component = True
-
     def __init__(self, data, **params):
         if not isinstance(data, util.basestring):
             raise TypeError('%s data has to be a tile service URL'
@@ -111,15 +123,13 @@ class WMTS(_Element):
         super(WMTS, self).__init__(data, **params)
 
 
-class Tiles(_Element):
+class Tiles(_GeoFeature):
     """
     Tiles represents an image tile source to dynamically
     load data from depending on the zoom level.
     """
 
     group = param.String(default='Tiles')
-
-    _auxiliary_component = True
 
     def __init__(self, data, **params):
         if not isinstance(data, cGoogleTiles):
@@ -134,8 +144,6 @@ class Points(_Element, Dataset):
     an associated cartopy coordinate-reference system.
     """
 
-    kdims = param.List(default=['longitude', 'latitude'])
-
     group = param.String(default='Points')
 
 
@@ -145,8 +153,6 @@ class LineContours(_Element, Dataset):
     some associated coordinates, which may be discretized
     into one or more line contours.
     """
-
-    kdims = param.List(default=[Dimension('x'), Dimension('y')])
 
     vdims = param.List(default=[Dimension('z')], bounds=(1, 1))
 
@@ -168,8 +174,6 @@ class Image(_Element, Dataset):
     Image represents a 2D array of some quantity with
     some associated coordinates.
     """
-
-    kdims = param.List(default=[Dimension('x'), Dimension('y')])
 
     vdims = param.List(default=[Dimension('z')], bounds=(1, 1))
 


### PR DESCRIPTION
This PR makes three main improvements:

1. Fix for the ``is_geographic`` function to correctly handle Tiles, WMTS and Feature Elements.

2. Only set the aspect to equal on geographic plot types, avoiding the issue raised in #15.

3. Add a get_extents method, which makes use of ``GeoAxes.set_extent`` to correctly compute the plot extents based on the range and extents of the Element. This allows setting extents on the Element in its native coordinate system.

Letting cartopy handle computing the extent transform is good, but it would be nice if we could factor out the code in cartopy's ``GeoAxes.set_extents`` to compute the extent transform without having to set it.