### PR TITLE
Updated docs to use xarray examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ multi-figure layouts of overlaid objects.
 
 ## Installation
 
-You will first probably want to install iris and/or xarray for working with
-multidimensional datasets:
+GeoViews requires cartopy, and most people will want iris and/or
+xarray as well:
 
 ```
 conda install -c scitools/label/dev -c conda-forge iris cartopy
 conda install xarray
 ```
 
-You can then install GeoViews and its dependencies using conda:
+You can then install GeoViews and its other dependencies using conda:
 
 ```
 conda install -c ioam holoviews geoviews

--- a/README.md
+++ b/README.md
@@ -27,25 +27,26 @@ multi-figure layouts of overlaid objects.
 
 ## Installation
 
-You can install GeoViews and its dependencies using conda:
+You will first probably want to install iris and/or xarray for working with
+multidimensional datasets:
 
 ```
 conda install -c scitools/label/dev -c conda-forge iris cartopy
+conda install xarray
+```
+
+You can then install GeoViews and its dependencies using conda:
+
+```
 conda install -c ioam holoviews geoviews
 ```
 
-You will probably also want a copy of the Iris sample data. Using
-conda install it with:
+You can now switch to your preferred working directory, grab a copy of
+the notebooks to run locally, and run them using the Jupyter notebook:: 
 
 ```
-conda install -c scitools iris_sample_data
-```
-
-You can now switch to your preferred working directory, grab a copy of the notebooks to run locally, and run them using Jupyter notebook::
-
-```
-mkdir ~/geoviews-examples
-cd ~/geoviews-examples
-python -c 'from geoviews import examples ; examples()'
+cd ~
+python -c 'import geoviews; geoviews.examples("geoviews-examples",include_data=True)'
+cd geoviews-examples
 jupyter notebook
 ```

--- a/doc/Geometries.ipynb
+++ b/doc/Geometries.ipynb
@@ -23,7 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cartopy and shapely make working with geometries and shapes very simple.  GeoViews provides convenient means of wrapping the various geometry types they provide. In addition to basic Path and Polygons types, which draw geometries from lists of arrays, GeoViews also provides the ``Feature`` and ``Shape`` types, which wrap cartopy Features and shapely geometries respectively.\n",
+    "Cartopy and shapely make working with geometries and shapes very simple, and GeoViews provides convenient wrappers for the various geometry types they provide. In addition to basic Path and Polygons types, which draw geometries from lists of arrays, GeoViews also provides the ``Feature`` and ``Shape`` types, which wrap cartopy Features and shapely geometries respectively.\n",
     "\n",
     "### Feature\n",
     "\n",
@@ -92,7 +92,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also iterate over the geometries and wrap them in an NdOverlay of ``gv.Shape`` Elements:"
+    "We can also iterate over the geometries and wrap them all in an NdOverlay of ``gv.Shape`` Elements:"
    ]
   },
   {
@@ -130,7 +130,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To combine these shapes with some actual data, we have to be able to merge it with a dataset. To do so we can inspect the records the cartopy shapereader loads:"
+    "To combine these shapes with some actual data, we have to be able to merge them with a dataset. To do so we can inspect the records the cartopy shapereader loads:"
    ]
   },
   {
@@ -149,7 +149,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we can see the record contains a ``MultiPolygon`` together with a standard geographic ``code``, which we can use to match up the geometries with a dataset. To continue we will require a dataset that is also indexed by these codes. For this purpose we load a dataset of the 2016 EU Referendum result in the UK:"
+    "As we can see, the record contains a ``MultiPolygon`` together with a standard geographic ``code``, which we can use to match up the geometries with a dataset. To continue we will require a dataset that is also indexed by these codes. For this purpose we load a dataset of the 2016 EU Referendum result in the UK:"
    ]
   },
   {
@@ -183,6 +183,13 @@
     "%%opts Shape (cmap='viridis')\n",
     "gv.Shape.from_records(shapes.records(), referendum, on='code', value='leaveVoteshare',\n",
     "                     index=['name', 'regionName'], crs=ccrs.PlateCarree())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The \"Working with Bokeh\" GeoViews notebook shows how to enable hover data that displays information about each of these shapes interactively."
    ]
   }
  ],

--- a/doc/Gridded_Datasets_I.ipynb
+++ b/doc/Gridded_Datasets_I.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "GeoViews is designed to make full use of data declared in the Iris data format, called \"cubes\".  This notebook shows how to use data in this format. The cubes used in this notebook are publicly available in the [``SciTools/iris-sample-data``](https://github.com/SciTools/iris-sample-data) repository."
+    "GeoViews is designed to make full use of data gridded datasets stored as array based data in netCDF or other common formats via the xarray and iris interfaces in HoloViews. This notebook will demonstrate how to load data using both of these data backends and some of their individual quirks. The data used in this notebook was originally shipped as part of the [``SciTools/iris-sample-data``](https://github.com/SciTools/iris-sample-data) repository, but a smaller netCDF file is included as part of the GeoViews."
    ]
   },
   {
@@ -15,9 +15,9 @@
    },
    "outputs": [],
    "source": [
-    "import datetime\n",
     "import iris\n",
     "import numpy as np\n",
+    "import xarray as xr\n",
     "import holoviews as hv\n",
     "import geoviews as gv\n",
     "from cartopy import crs\n",
@@ -47,7 +47,6 @@
    },
    "outputs": [],
    "source": [
-    "iris.FUTURE.strict_grib_load = True\n",
     "%opts Image {+framewise} [colorbar=True] Curve [xrotation=60]"
    ]
   },
@@ -81,14 +80,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Loading our first cube"
+    "## Loading our data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is the summary of the first cube, which contains some surface temperature data:"
+    "In this notebook we will primarily be working with xarray, however to demonstrate that iris and xarray are basically equivalent we will load the same dataset using both backends.\n",
+    "\n",
+    "#### XArray\n",
+    "\n",
+    "As a first step we simply load the data using the ``open_dataset`` method xarray provides and have a look at the repr to get an overview what is in this dataset:"
    ]
   },
   {
@@ -99,9 +102,17 @@
    },
    "outputs": [],
    "source": [
-    "iris_cube = iris.load_cube(iris.sample_data_path('GloSea4', 'ensemble_001.pp'))\n",
-    "iris_cube.coord('latitude').guess_bounds()\n",
-    "iris_cube.coord('longitude').guess_bounds()"
+    "xr_ensemble = xr.open_dataset('ensemble.nc')\n",
+    "xr_ensemble"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Iris\n",
+    "\n",
+    "Similarly we can load the same dataset using Iris' ``load_cube`` function and get a similar overview using the ``summary`` method."
    ]
   },
   {
@@ -112,14 +123,18 @@
    },
    "outputs": [],
    "source": [
-    "print iris_cube.summary()"
+    "iris.FUTURE.netcdf_promote=True\n",
+    "iris_ensemble = iris.load_cube('ensemble.nc')\n",
+    "print iris_ensemble.summary()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can wrap this Iris cube in a ``Dataset``:"
+    "Describing the differences between these two libraries is well beyond the scope of this tutorial, but you will notice from the summaries that the two libraries deal differently with both the bounds and with the actual data variables. Iris cubes support only a single data variable, while an xarray dataset can have any number of variables. In this case we are only interested in the ``surface_temperature`` dimension, indexed by ``longitude``, ``latitude`` and ``time``.\n",
+    "\n",
+    "We can easily express this by wrapping the data in a GeoViews ``Dataset`` Element and declaring the key dimensions (``kdims``) and value dimensions (``vdims``). Note that the Iris interface is much smarter in the way it extracts the dimensions so usually you will not have to supply them explicitly."
    ]
   },
   {
@@ -130,19 +145,81 @@
    },
    "outputs": [],
    "source": [
-    "surface_temperature = hv.Dataset(iris_cube)\n",
-    "surface_temperature"
+    "kdims = ['time', 'longitude', 'latitude']\n",
+    "vdims = ['surface_temperature']\n",
+    "\n",
+    "xr_dataset = gv.Dataset(xr_ensemble, kdims=kdims, vdims=vdims, crs=crs.PlateCarree())\n",
+    "iris_dataset = gv.Dataset(iris_ensemble)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, this `Dataset` is not yet visualizable, because we have not chosen which dimensions to map onto which axes of a plot.\n",
+    "Now we can compare the repr of the two Elements:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print repr(xr_dataset)\n",
+    "print repr(iris_dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "They now appear identical, however there are some differences between these two, specifically the types are not necessarily consistent. Here we can see that xarray uses NumPy datetime64 types for dates while iris will use simple floats:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "print(\"XArray time type: %s\" % xr_dataset.get_dimension_type('time'))\n",
+    "print(\"Iris time type: %s\" % iris_dataset.get_dimension_type('time'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To improve the formatting of dates on the xarray dataset we can set the formatter for datetime64 types:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The other major differences in the way iris cubes are handled are in deducing various bits of metadata including the coordinate system, units and formatters. Otherwise the two Dataset Elements will behave largely the same.\n",
+    "\n",
+    "However, in this form the `Dataset` is not yet visualizable, because we have not chosen which dimensions to map onto which axes of a plot.\n",
     "\n",
     "# A Simple example\n",
     "\n",
-    "To visualize the ``surface_temperature`` cube, in a single line of code we can specify that we want to view it as a collection of Images indexed by longitude and latitude (a HoloViews ``HoloMap`` of ``gv.Image`` elements):"
+    "To visualize the datasets, in a single line of code we can specify that we want to view it as a collection of Images indexed by longitude and latitude (a HoloViews ``HoloMap`` of ``gv.Image`` elements):"
    ]
   },
   {
@@ -153,14 +230,14 @@
    },
    "outputs": [],
    "source": [
-    "surface_temperature.to(gv.Image,['longitude', 'latitude'])"
+    "xr_dataset.to(gv.Image, ['longitude', 'latitude'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see that the `time` dimension was automatically mapped to a slider, because we did not map it onto one of the other available dimensions (x, y, or color, in this case). You can drag the slider to view the surface temperature at different times. The available `time` values can be shown by using the HoloViews API:"
+    "Notice how we also had to specify the coordinate reference system (``crs``). This is because xarray does not extract a coordinate system from the data. Iris on the other hand makes that information available automatically, which means we don't have to declare it explicitly:"
    ]
   },
   {
@@ -171,25 +248,14 @@
    },
    "outputs": [],
    "source": [
-    "surface_temperature.dimension_values('time')"
+    "iris_dataset.to(gv.Image, ['longitude', 'latitude'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The human-readable times shown in the slider are long, making the text rather small. We can use the fact that all times are recorded in the year 2011 on the 16th of each month to shorten these dates. Defining how all dates should be formatted as follows will help with readability:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "hv.Dimension.type_formatters[datetime.datetime] = \"%m/%y %Hh\""
+    "You can see that in both cases the `time` dimension was automatically mapped to a slider, because we did not map it onto one of the other available dimensions (x, y, or color, in this case). You can drag the slider to view the surface temperature at different times."
    ]
   },
   {
@@ -207,11 +273,10 @@
    },
    "outputs": [],
    "source": [
-    "air_temperature = hv.Dataset(iris.load_cube(iris.sample_data_path('pre-industrial.pp')),\n",
-    "                             group='Pre-industrial air temperature')\n",
-    "air_temperature.data.coord('longitude').guess_bounds()\n",
-    "air_temperature.data.coord('latitude').guess_bounds()\n",
-    "air_temperature     # Use air_temperature.data.summary() to see the Iris summary (.data is the Iris cube)"
+    "air_temperature = gv.Dataset(xr.open_dataset('pre-industrial.nc'), kdims=['longitude', 'latitude'],\n",
+    "                             group='Pre-industrial air temperature', vdims=['air_temperature'],\n",
+    "                             crs=crs.PlateCarree())\n",
+    "air_temperature"
    ]
   },
   {
@@ -229,9 +294,9 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Layout [fig_inches=(12,4)]\n",
-    "(surface_temperature.to.image(['longitude', 'latitude'])+\n",
-    " air_temperature.to.image(['longitude', 'latitude'])(plot=dict(projection=crs.PlateCarree())))"
+    "%%opts Layout [fig_inches=(12,3.5)]\n",
+    "(xr_dataset.to.image(['longitude', 'latitude'])+\n",
+    " air_temperature.to.image(['longitude', 'latitude']))"
    ]
   },
   {
@@ -251,13 +316,13 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Layout [fig_inches=(12,7)] Curve [aspect=2 xticks=4 xrotation=15] Points (color=2)\n",
+    "%%opts Layout [fig_inches=(12,7)] Curve [aspect=1.8 xticks=4 xrotation=15] Points (color=2)\n",
     "%%opts Image [projection=crs.PlateCarree()]\n",
     "\n",
-    "temp_curve = hv.Curve(surface_temperature.select(longitude=0, latitude=10), kdims=['time'])\n",
+    "temp_curve = hv.Curve(xr_dataset.select(longitude=0, latitude=10), kdims=['time'])\n",
     "\n",
     "temp_maps = [cb.to(gv.Image,['longitude', 'latitude']) * gv.Points([(0,10)]) \n",
-    "             for cb in [surface_temperature, air_temperature]]\n",
+    "             for cb in [xr_dataset, air_temperature]]\n",
     "\n",
     "hv.Layout(temp_maps + [temp_curve]).cols(2).display('all')"
    ]
@@ -284,8 +349,8 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Image [projection=crs.Geostationary()] (cmap='Greens')\n",
-    "surface_temperature.to.image(['longitude', 'latitude']) * gv.Feature(cf.COASTLINE)"
+    "%%opts Image [projection=crs.Geostationary()] (cmap='Greens') Overlay [xaxis=None yaxis=None]\n",
+    "xr_dataset.to.image(['longitude', 'latitude']) * gv.Feature(cf.COASTLINE)"
    ]
   },
   {
@@ -294,7 +359,7 @@
    "source": [
     "Notice that every frame individually uses the full dynamic range of the Greens color map. This is because normalization is set to ``+framewise`` at the top of the notebook, which means every frame is normalized independently. This sort of normalization can be computed on an as-needed basis, using whatever values are found in the current data being shown in a given frame, but it won't let you see how different frames compare to each other.\n",
     "\n",
-    "To control normalization, we need to decide on the normalization limits. Let's see the maximum temperature in the cube, and use it to set a normalization range by declaring a value dimension for the Dataset:"
+    "To control normalization, we need to decide on the normalization limits. Let's see the maximum temperature in the cube, and use it to set a normalization range by using the redim method:"
    ]
   },
   {
@@ -305,21 +370,10 @@
    },
    "outputs": [],
    "source": [
-    "max_surface_temp = surface_temperature.data.data.max()\n",
-    "max_surface_temp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "%%opts Image [projection=crs.Geostationary()] (cmap='Greens')\n",
-    "surface_temp_dim = hv.Dimension('surface_temperature', range=(300, max_surface_temp))\n",
-    "hv.Dataset(surface_temperature, vdims=[surface_temp_dim]).to(gv.Image,['longitude', 'latitude']) \\\n",
+    "%%opts Image [projection=crs.Geostationary()] (cmap='Greens') Overlay [xaxis=None yaxis=None]\n",
+    "max_surface_temp = xr_dataset.range('surface_temperature')[1]\n",
+    "print max_surface_temp\n",
+    "xr_dataset.redim(surface_temperature=dict(range=(300, max_surface_temp))).to(gv.Image,['longitude', 'latitude']) \\\n",
     "  * gv.Feature(cf.COASTLINE)"
    ]
   },
@@ -345,7 +399,7 @@
    },
    "outputs": [],
    "source": [
-    "surface_temperature.to(gv.FilledContours,['longitude', 'latitude']) * gv.Feature(cf.COASTLINE)"
+    "xr_dataset.to(gv.FilledContours,['longitude', 'latitude']) * gv.Feature(cf.COASTLINE)"
    ]
   },
   {
@@ -373,7 +427,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.11"
   },
   "widgets": {
    "state": {},

--- a/doc/Gridded_Datasets_I.ipynb
+++ b/doc/Gridded_Datasets_I.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "GeoViews is designed to make full use of data gridded datasets stored as array based data in netCDF or other common formats via the xarray and iris interfaces in HoloViews. This notebook will demonstrate how to load data using both of these data backends and some of their individual quirks. The data used in this notebook was originally shipped as part of the [``SciTools/iris-sample-data``](https://github.com/SciTools/iris-sample-data) repository, but a smaller netCDF file is included as part of the GeoViews."
+    "GeoViews is designed to make full use of multidimensional gridded datasets stored in netCDF or other common formats, via the xarray and iris interfaces in HoloViews. This notebook will demonstrate how to load data using both of these data backends, along with some of their individual quirks. The data used in this notebook was originally shipped as part of the [``SciTools/iris-sample-data``](https://github.com/SciTools/iris-sample-data) repository, but a smaller netCDF file is included as part of the GeoViews so that it can be used with xarray as well."
    ]
   },
   {
@@ -54,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that it is easy to set global defaults for a project, allowing any suitable settings to be made into a default on a per-element-type basis. Now let's specify the maximum number of frames we will be displaying:"
+    "You can see that it is easy to set global defaults for a project, allowing any suitable settings to be made into a default on a per-element-type basis. Now let's specify the maximum number of frames we will be displaying:"
    ]
   },
   {
@@ -87,7 +87,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we will primarily be working with xarray, however to demonstrate that iris and xarray are basically equivalent we will load the same dataset using both backends.\n",
+    "In this notebook we will primarily be working with xarray, but we will also load the same data using iris so that we can demonstrate that the two data backends are nearly equivalent.\n",
     "\n",
     "#### XArray\n",
     "\n",
@@ -132,9 +132,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Describing the differences between these two libraries is well beyond the scope of this tutorial, but you will notice from the summaries that the two libraries deal differently with both the bounds and with the actual data variables. Iris cubes support only a single data variable, while an xarray dataset can have any number of variables. In this case we are only interested in the ``surface_temperature`` dimension, indexed by ``longitude``, ``latitude`` and ``time``.\n",
+    "Describing the differences between these two libraries is well beyond the scope of this tutorial, but you can see from the summaries that the two libraries deal differently with both the bounds and with the actual data variables. Iris cubes support only a single data variable, while an xarray dataset can have any number of variables. In this case we are only interested in the ``surface_temperature`` dimension, indexed by ``longitude``, ``latitude`` and ``time``.\n",
     "\n",
-    "We can easily express this by wrapping the data in a GeoViews ``Dataset`` Element and declaring the key dimensions (``kdims``) and value dimensions (``vdims``). Note that the Iris interface is much smarter in the way it extracts the dimensions so usually you will not have to supply them explicitly."
+    "We can easily express this interest by wrapping the data in a GeoViews ``Dataset`` Element and declaring the key dimensions (``kdims``) and value dimensions (``vdims``). Note that the Iris interface is much smarter in the way it extracts the dimensions, so usually you will not have to supply them explicitly."
    ]
   },
   {
@@ -175,7 +175,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "They now appear identical, however there are some differences between these two, specifically the types are not necessarily consistent. Here we can see that xarray uses NumPy datetime64 types for dates while iris will use simple floats:"
+    "Despite appearing identical, there are some internal differences, such as in the data types. xarray uses NumPy datetime64 types for dates, while iris will use simple floats:"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To improve the formatting of dates on the xarray dataset we can set the formatter for datetime64 types:"
+    "To improve the formatting of dates on the xarray dataset, we can set the formatter for datetime64 types:"
    ]
   },
   {
@@ -213,9 +213,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The other major differences in the way iris cubes are handled are in deducing various bits of metadata including the coordinate system, units and formatters. Otherwise the two Dataset Elements will behave largely the same.\n",
+    "The other major differences in the way iris cubes are handled are in deducing various bits of metadata including the coordinate system, units, and formatters. Otherwise the two Dataset Elements will behave largely the same.\n",
     "\n",
-    "However, in this form the `Dataset` is not yet visualizable, because we have not chosen which dimensions to map onto which axes of a plot.\n",
+    "For either data backend, the `Dataset` object is not yet visualizable, because we have not chosen which dimensions to map onto which axes of a plot.\n",
     "\n",
     "# A Simple example\n",
     "\n",
@@ -231,13 +231,6 @@
    "outputs": [],
    "source": [
     "xr_dataset.to(gv.Image, ['longitude', 'latitude'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Notice how we also had to specify the coordinate reference system (``crs``). This is because xarray does not extract a coordinate system from the data. Iris on the other hand makes that information available automatically, which means we don't have to declare it explicitly:"
    ]
   },
   {
@@ -303,9 +296,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next is a fairly involved example that plots an arbitrary number of HoloViews objects side by side in a ``Layout``, rather than using the fixed-layout ``+`` operator. \n",
+    "The above plot shows how to combine a fixed number of plots using ``+``, but what if you want to combine some arbitrarily long list of objects?  You can do that by making a ``Layout`` explicitly, which is what ``+`` does internally.\n",
     "\n",
-    "This example shows how complex interactive plots can be generated with relatively little code, and also demonstrates how different HoloViews elements can be combined together. In the following visualization, the curve is a sample of the ``surface_temperature`` at longitude and latitude *(0,10)*, and it is unaffected by the `time` slider because it already lays out time along the x axis:"
+    "The following more complicated example shows how complex interactive plots can be generated with relatively little code, and also demonstrates how different HoloViews elements can be combined together. In the following visualization, the black dot denotes a specific longitude, latitude location *(0,10)*, and the curve is a sample of the ``surface_temperature`` at that location.  The curve is unaffected by the `time` slider because it already lays out time along the x axis:"
    ]
   },
   {
@@ -317,10 +310,8 @@
    "outputs": [],
    "source": [
     "%%opts Layout [fig_inches=(12,7)] Curve [xticks=4 xrotation=15] Points (color='k')\n",
-    "#%%opts Image [projection=crs.PlateCarree()]\n",
     "\n",
     "temp_curve = hv.Curve(xr_dataset.select(longitude=0, latitude=10), kdims=['time'])\n",
-    "\n",
     "temp_maps = [cb.to(gv.Image,['longitude', 'latitude']) * gv.Points([(0,10)], crs=crs.PlateCarree()) \n",
     "             for cb in [xr_dataset, air_temperature]]\n",
     "\n",
@@ -373,8 +364,8 @@
     "%%opts Image [projection=crs.Geostationary()] (cmap='Greens') Overlay [xaxis=None yaxis=None]\n",
     "max_surface_temp = xr_dataset.range('surface_temperature')[1]\n",
     "print max_surface_temp\n",
-    "xr_dataset.redim(surface_temperature=dict(range=(300, max_surface_temp))).to(gv.Image,['longitude', 'latitude']) \\\n",
-    "  * gv.Feature(cf.COASTLINE)"
+    "xr_dataset.redim(surface_temperature=dict(range=(300, max_surface_temp))).\\\n",
+    "  to(gv.Image,['longitude', 'latitude']) * gv.Feature(cf.COASTLINE)"
    ]
   },
   {
@@ -406,7 +397,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, it's quite simple to expose any data you like from your Iris cube, easily and flexibly creating interactive or static visualizations."
+    "As you can see, it's quite simple to expose any data you like from your Iris cube or xarray, easily and flexibly creating interactive or static visualizations."
    ]
   }
  ],

--- a/doc/Gridded_Datasets_I.ipynb
+++ b/doc/Gridded_Datasets_I.ipynb
@@ -102,7 +102,7 @@
    },
    "outputs": [],
    "source": [
-    "xr_ensemble = xr.open_dataset('ensemble.nc')\n",
+    "xr_ensemble = xr.open_dataset('./sample-data/ensemble.nc')\n",
     "xr_ensemble"
    ]
   },
@@ -124,7 +124,7 @@
    "outputs": [],
    "source": [
     "iris.FUTURE.netcdf_promote=True\n",
-    "iris_ensemble = iris.load_cube('ensemble.nc')\n",
+    "iris_ensemble = iris.load_cube('./sample-data/ensemble.nc')\n",
     "print iris_ensemble.summary()"
    ]
   },
@@ -273,7 +273,7 @@
    },
    "outputs": [],
    "source": [
-    "air_temperature = gv.Dataset(xr.open_dataset('pre-industrial.nc'), kdims=['longitude', 'latitude'],\n",
+    "air_temperature = gv.Dataset(xr.open_dataset('./sample-data/pre-industrial.nc'), kdims=['longitude', 'latitude'],\n",
     "                             group='Pre-industrial air temperature', vdims=['air_temperature'],\n",
     "                             crs=crs.PlateCarree())\n",
     "air_temperature"

--- a/doc/Gridded_Datasets_I.ipynb
+++ b/doc/Gridded_Datasets_I.ipynb
@@ -316,12 +316,12 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Layout [fig_inches=(12,7)] Curve [aspect=1.8 xticks=4 xrotation=15] Points (color=2)\n",
-    "%%opts Image [projection=crs.PlateCarree()]\n",
+    "%%opts Layout [fig_inches=(12,7)] Curve [xticks=4 xrotation=15] Points (color='k')\n",
+    "#%%opts Image [projection=crs.PlateCarree()]\n",
     "\n",
     "temp_curve = hv.Curve(xr_dataset.select(longitude=0, latitude=10), kdims=['time'])\n",
     "\n",
-    "temp_maps = [cb.to(gv.Image,['longitude', 'latitude']) * gv.Points([(0,10)]) \n",
+    "temp_maps = [cb.to(gv.Image,['longitude', 'latitude']) * gv.Points([(0,10)], crs=crs.PlateCarree()) \n",
     "             for cb in [xr_dataset, air_temperature]]\n",
     "\n",
     "hv.Layout(temp_maps + [temp_curve]).cols(2).display('all')"

--- a/doc/Gridded_Datasets_II.ipynb
+++ b/doc/Gridded_Datasets_II.ipynb
@@ -15,7 +15,7 @@
     "from cartopy import crs as ccrs\n",
     "from cartopy import feature as cf\n",
     "\n",
-    "hv.notebook_extension('bokeh')\n",
+    "hv.notebook_extension()\n",
     "%output size=200"
    ]
   },
@@ -43,7 +43,7 @@
    },
    "outputs": [],
    "source": [
-    "xr_ensembles = xr.open_dataset('ensembles.nc')\n",
+    "xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')\n",
     "xr_ensembles"
    ]
   },

--- a/doc/Gridded_Datasets_II.ipynb
+++ b/doc/Gridded_Datasets_II.ipynb
@@ -72,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the repr we can immediately see the list of key dimensions (time, realization, longitude and latitude) and the value dimension of the cube (surface_temperature). However, unlike most other HoloViews Elements, the ``Dataset`` Element does not display itself visually. This is because it can be n-dimensional and therefore does not have any specific straightforward visual representation in general. To view the cube, we first have to transform it into individually visualizable chunks but before doing so we might want to rename one of the dimensions and supply a custom value formatter for the time dimension:"
+    "From the repr we can immediately see the list of key dimensions (time, realization, longitude and latitude) and the value dimension of the cube (surface_temperature). However, unlike most other HoloViews Elements, the ``Dataset`` Element does not display itself visually. This is because it can be n-dimensional and therefore does not have any specific straightforward visual representation on a 2D display. To view the cube, we first have to transform it into individually visualizable chunks.  Before doing so, we will want to supply a custom value formatter for the time dimension so that it is readable by humans:"
    ]
   },
   {
@@ -94,9 +94,9 @@
     "\n",
     "A HoloViews Dataset is a wrapper around a complex multi-dimensional datastructure which allows the user to convert their data into individually visualizable views, each usually of lower dimensionality. This is done by grouping the data by some dimension and then casting it to a specific Element type, which visualizes itself.\n",
     "\n",
-    "The ``dataset.to`` interface makes this especially easy.  To use it, you supply the Element type that you want to view the data as and the key dimensions of that view and it will figure out the rest. Depending on the type of Element, you can specify one or more dimensions to be displayed. This means that only certain Elements allow you to display the data on a cartographic projection. Recall that the cube we are working with has 4 coordinate dimensions (or key dimensions as they are known in HoloViews) -- time, realization, longitude and latitude. \n",
+    "The ``dataset.to`` interface makes this especially easy.  To use it, you supply the Element type that you want to view the data as and the key dimensions of that view and it will figure out the rest. Depending on the type of Element, you can specify one or more dimensions to be displayed. GeoViews provides a set of GeoElements that allow you to display geographic data on a cartographic projection, but you can use any Elements from HoloViews for non-geographic plots.\n",
     "\n",
-    "For our purposes, a geographic plot is defined as a plot that has longitude along the x axis and latitude along the y axis. To declare a two-dimensional plot type, we therefore simply request a `gv.Image` plot of ``longitude`` and ``latitude``. All the remaining dimensions are automatically inferred.  I.e., the value dimension (vdim) is ``surface_temperature``, and any remaining dimensions are assigned to a ``HoloMap`` data structure by default, which allows you to explore the data using widgets:"
+    "Recall that the cube we are working with has 4 coordinate dimensions (or key dimensions as they are known in HoloViews) -- time, realization, longitude, and latitude.  For our purposes, a geographic plot is defined as a plot that has longitude along the x axis and latitude along the y axis. To declare a two-dimensional geographic plot, we therefore simply request a `gv.Image` plot with ``longitude`` and ``latitude`` as key dimensions.  There is one value dimension (vdim) available, ``surface_temperature``, and any remaining key dimensions (``time`` and ``realization`` in this case) are assigned to a ``HoloMap`` data structure by default.  The resulting ``HoloMap`` gives you widgets automatically to allow you to explore the data across the two \"remaining\" key dimensions (those not mapped onto axes of the image):"
    ]
   },
   {
@@ -117,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this way we can visualize the 2D data in a number of ways, currently either as an ``Image`` (as above) or as ``LineContours``, ``FilledContours``, or ``Points``:"
+    "In this way we can visualize the geographic data in a number of ways, currently either as an ``Image`` (as above) or as ``LineContours``, ``FilledContours``, or ``Points``:"
    ]
   },
   {
@@ -156,11 +156,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This means that the data for each frame is only extracted when you're actually viewing that part of the data, which can have huge benefits in terms of speed and memory consumption.\n",
+    "Using ``dynamic`` mode means that the data for each frame is only extracted when you're actually viewing that part of the data, which can have huge benefits in terms of speed and memory consumption.  However, it relies on having a running Python process to render and serve each image, and so it cannot be used when generating static HTML output such as for the GeoViews web site.\n",
+    "\n",
     "\n",
     "## Non-geographic views\n",
     "\n",
-    "So far we have focused entirely on geographic views of the data, plotting the data on a projection. However the conversion interface is completely general, allowing us to slice and dice the data in any way we like. The simplest example of such a view is simply a view showing the temperature over time for each realization, longitude, and latitude coordinate:"
+    "So far we have focused entirely on geographic views of the data, plotting the data on a projection. However the conversion interface is completely general, allowing us to slice and dice the data in any way we like. The simplest example of this capability is simply a view showing the temperature over time for each realization, longitude, and latitude coordinate:"
    ]
   },
   {
@@ -172,14 +173,16 @@
    "outputs": [],
    "source": [
     "%%opts Curve [xrotation=25 aspect=2]\n",
-    "dataset.to(hv.Curve, 'time', dynamic=True)"
+    "dataset.to(hv.Curve, 'time', dynamic=True).overlay('realization')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another possible view is to show the data as a ``HeatMap`` over time and realization at a specified longitude and latitude:"
+    "Note that the longitude slider will have no effect, if latitude is -90 or +90, since there is only one data point for the North or South poles (regardless of the declared longitude).  Here the `.overlay` gives a different curve for each `realization`; without it all `realization` values would be pooled together.\n",
+    "\n",
+    "We can also make non-geographic 2D plots, for instance as a ``HeatMap`` over time and realization, at a specified longitude and latitude:"
    ]
   },
   {
@@ -200,7 +203,7 @@
    "source": [
     "## Lower-dimensional views\n",
     "\n",
-    "So far all the conversions shown have incorporated each of the available coordinate dimensions. However, often times we want to see the spread of values along one or more dimensions, ignoring other dimensions. A simple example of this is a box plot where we might want to see the spread of surface_temperature on each day, pooled across all latitude and longitude coordinates. To ignore particular dimensions we can explicitly declare the map dimensions (i.e. the key dimensions of the HoloMap container). By declaring an empty list of ``mdims``, we can tell the conversion interface to simply ignore all dimensions except the particular key dimension that was supplied, in this case the `'time'` and `'realization'`:"
+    "So far all the conversions shown have incorporated each of the available coordinate dimensions explicitly. However, often times we want to see the spread of values along one or more dimensions, pooling all the other dimensions together. A simple example of this is a box plot where we might want to see the spread of surface_temperature on each day, pooled across all latitude and longitude coordinates. To pool across particular dimensions, we can explicitly declare the \"map\" dimensions, which are the key dimensions of the HoloMap container rather than those of the Elements contained in the HoloMap. By declaring an empty list of ``mdims``, we can tell the conversion interface to pool across all dimensions *except* the particular key dimension(s) supplied, in this case the `'time'` (plot **A**) and `'realization'` (plot **B**):"
    ]
   },
   {
@@ -219,7 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This approach also gives us access to other statistical plot types. For instance, with the ``seaborn`` library installed, we also have access to the ``Distribution`` Element, which visualizes the data as a kernel density estimate. In this way we can visualize how the distribution of surface temperature values varies over time and the model realizations. We do this by ignoring the 'latitude' and 'longitude' in the list of mdims, generating a lower-dimensional view into the data and laying out `'time'` and `'realization'` in a `GridSpace`."
+    "This approach also gives us access to other statistical plot types. For instance, with the ``seaborn`` library installed, we can use the ``Distribution`` Element, which visualizes the data as a kernel density estimate. In this way we can visualize how the distribution of surface temperature values varies over time and the model realizations. We do this by omitting 'latitude' and 'longitude' from the list of mdims, generating a lower-dimensional view into the data, where a temperature histogram is shown for every `'realization'` and `'time'`, using `GridSpace`:"
    ]
   },
   {
@@ -246,11 +249,11 @@
    "source": [
     "## Reducing the data\n",
     "\n",
-    "So far all the examples we have seen have displayed all the data in some way or another. Another way to explore a dataset is to explicitly reduce the dimensionality or select subregions of a dataset. There are two main ways to do this, either we explicitly select a subset of the data, or we collapse a dimension using an aggregation function, e.g. by computing a mean along a particular dimension.\n",
+    "So far all the examples we have seen have displayed all the data in some way or another. Another way to explore a dataset is to explicitly reduce the dimensionality or select subregions of a dataset. There are two main ways to do this---either we explicitly select a subset of the data, or we collapse a dimension using an aggregation function, e.g. by computing a mean along a particular dimension.\n",
     "\n",
     "### Selecting slices\n",
     "\n",
-    "Using the ``select`` method we can easily select ranges of coordinates in the dataset. The select method does not however know that latitude and longitude are cyclic, so instead we can select regions at both ends of the prime meridian (0$^\\circ$ longitude) and overlay them. In this way we can stitch together multiple cubes or simply view specific subregions:"
+    "Using the ``select`` method we can easily select ranges of coordinates in the dataset. Unfortunately, the select method does not currently know that latitude and longitude are cyclic, so instead we have to select regions at both ends of the prime meridian (0$^\\circ$ longitude) and overlay them. In this way we can stitch together multiple cubes or xarrays or simply view specific subregions:"
    ]
   },
   {
@@ -273,7 +276,7 @@
    "source": [
     "### Selecting a particular coordinate\n",
     "\n",
-    "We can select a particular coordinate using the select method, cast the data to Curves, reindex the data to drop the now constant latitude and longitude dimensions, and overlay the remaining 'realization' dimension."
+    "To examine one particular coordinate, we can ``select`` it, cast the data to Curves, reindex the data to drop the now-constant latitude and longitude dimensions, and overlay the remaining 'realization' dimension:"
    ]
   },
   {
@@ -294,7 +297,7 @@
    "source": [
     "### Aggregating coordinates\n",
     "\n",
-    "Another option is to aggregate over certain dimensions, in this way we can get an idea of distributions of temperatures across all latitudes and longitudes. Here we compute the mean temperature and standard deviation by latitude and longitude and cast the resulting collapsed view to a Spread Element:"
+    "Another option is to aggregate over certain dimensions, so that we can get an idea of distributions of temperatures across all latitudes and longitudes. Here we compute the mean temperature and standard deviation by latitude and longitude, casting the resulting collapsed view to a Spread Element:"
    ]
   },
   {
@@ -314,7 +317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, it is very simple to select precisely which aspects of a complex, multidimensional datasets that you want to focus on."
+    "As you can see, with GeoViews and HoloViews it is very simple to select precisely which aspects of complex, multidimensional datasets that you want to focus on."
    ]
   }
  ],

--- a/doc/Gridded_Datasets_II.ipynb
+++ b/doc/Gridded_Datasets_II.ipynb
@@ -8,14 +8,14 @@
    },
    "outputs": [],
    "source": [
-    "import iris\n",
     "import numpy as np\n",
+    "import xarray as xr\n",
     "import holoviews as hv\n",
     "import geoviews as gv\n",
     "from cartopy import crs as ccrs\n",
     "from cartopy import feature as cf\n",
     "\n",
-    "hv.notebook_extension()\n",
+    "hv.notebook_extension('bokeh')\n",
     "%output size=200"
    ]
   },
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The main strength of [HoloViews](http://holoviews.org) and its extensions (like GeoViews) is the ability to quickly explore complex datasets by declaring lower-dimensional views into a higher-dimensional space. In HoloViews we refer to the interface that allows you to do this as the conversion API. To begin with we will load a multi-dimensional dataset of surface temperatures for different \"realizations\" (modelling parameters) using [Iris](http://scitools.org.uk/iris/):"
+    "The main strength of [HoloViews](http://holoviews.org) and its extensions (like GeoViews) is the ability to quickly explore complex datasets by declaring lower-dimensional views into a higher-dimensional space. In HoloViews we refer to the interface that allows you to do this as the conversion API. To begin with we will load a multi-dimensional dataset of surface temperatures for different \"realizations\" (modelling parameters) using [XArray](https://github.com/pydata/xarray/):"
    ]
   },
   {
@@ -43,26 +43,15 @@
    },
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import iris\n",
-    "import iris.coords\n",
-    "\n",
-    "def realization_metadata(cube, field, fname):\n",
-    "    if not cube.coords('realization'):\n",
-    "        realization_number = fname[-6:-3]\n",
-    "        realization_coord = iris.coords.AuxCoord(np.int32(realization_number), 'realization')\n",
-    "        cube.add_aux_coord(realization_coord)\n",
-    "\n",
-    "surface_temp = iris.load_cube(iris.sample_data_path('GloSea4', 'ensemble_???.pp'),\n",
-    "              iris.Constraint('surface_temperature', realization=lambda value: True),\n",
-    "              callback=realization_metadata)"
+    "xr_ensembles = xr.open_dataset('ensembles.nc')\n",
+    "xr_ensembles"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we saw in the [Iris Datasets I Tutorial](Iris_Datasets_I.ipynb) we can easily wrap this Iris Cube data structure as a HoloViews Dataset:"
+    "As we saw in the [Gridded Datasets I Tutorial](Gridded_Datasets_I.ipynb) we can easily wrap this xarray data structure as a HoloViews Dataset:"
    ]
   },
   {
@@ -73,16 +62,34 @@
    },
    "outputs": [],
    "source": [
-    "cube = hv.Dataset(surface_temp).redim(surface_temperature='Temperature')\n",
-    "cube"
+    "kdims = ['realization', 'longitude', 'latitude', 'time']\n",
+    "vdims = ['surface_temperature']\n",
+    "dataset = gv.Dataset(xr_ensembles, kdims=kdims, vdims=vdims, crs=ccrs.PlateCarree())\n",
+    "dataset"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the repr we can immediately see the list of key dimensions (time, realization, longitude and latitude) and the value dimension of the cube (surface_temperature). However, unlike most other HoloViews Elements, the ``Dataset`` Element does not display itself visually. This is because it can be n-dimensional and therefore does not have any specific straightforward visual representation in general. To view the cube, we first have to transform it into individually visualizable chunks.\n",
-    "\n",
+    "From the repr we can immediately see the list of key dimensions (time, realization, longitude and latitude) and the value dimension of the cube (surface_temperature). However, unlike most other HoloViews Elements, the ``Dataset`` Element does not display itself visually. This is because it can be n-dimensional and therefore does not have any specific straightforward visual representation in general. To view the cube, we first have to transform it into individually visualizable chunks but before doing so we might want to rename one of the dimensions and supply a custom value formatter for the time dimension:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Conversions\n",
     "\n",
     "A HoloViews Dataset is a wrapper around a complex multi-dimensional datastructure which allows the user to convert their data into individually visualizable views, each usually of lower dimensionality. This is done by grouping the data by some dimension and then casting it to a specific Element type, which visualizes itself.\n",
@@ -96,13 +103,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [],
    "source": [
     "geo_dims = ['longitude', 'latitude']\n",
     "coastline = gv.Feature(cf.COASTLINE)\n",
-    "(cube.to(gv.Image, geo_dims) * coastline)[::5, ::5]"
+    "(dataset.to(gv.Image, geo_dims) * coastline)[::5, ::5]"
    ]
   },
   {
@@ -122,7 +130,7 @@
    "source": [
     "%%opts Layout [fig_inches=(4, 8)]\n",
     "%%opts Points [color_index=2 size_index=None] (cmap='jet')\n",
-    "hv.Layout([cube.to(el, geo_dims)[::5, ::5] * coastline\n",
+    "hv.Layout([dataset.to(el, geo_dims)[::5, ::5] * coastline\n",
     "           for el in [gv.FilledContours, gv.LineContours, gv.Points]]).cols(1)"
    ]
   },
@@ -141,7 +149,7 @@
    },
    "outputs": [],
    "source": [
-    "cube.to(gv.Image, geo_dims, dynamic=True) * coastline"
+    "dataset.to(gv.Image, geo_dims, dynamic=True) * coastline"
    ]
   },
   {
@@ -164,7 +172,7 @@
    "outputs": [],
    "source": [
     "%%opts Curve [xrotation=25 aspect=2]\n",
-    "cube.to(hv.Curve, 'time', dynamic=True)"
+    "dataset.to(hv.Curve, 'time', dynamic=True)"
    ]
   },
   {
@@ -183,7 +191,7 @@
    "outputs": [],
    "source": [
     "%%opts HeatMap [show_values=False colorbar=True]\n",
-    "cube.to(hv.HeatMap, ['realization', 'time'], dynamic=True)"
+    "dataset.to(hv.HeatMap, ['realization', 'time'], dynamic=True)"
    ]
   },
   {
@@ -204,7 +212,7 @@
    "outputs": [],
    "source": [
     "%%opts BoxWhisker [xrotation=25 bgcolor='w']\n",
-    "hv.Layout([cube.to.box(d, mdims=[]) for d in ['time', 'realization']])"
+    "hv.Layout([dataset.to.box(d, mdims=[]) for d in ['time', 'realization']])"
    ]
   },
   {
@@ -226,7 +234,7 @@
     "%opts Distribution [bgcolor='w' show_grid=False xticks=[220, 300]]\n",
     "try:\n",
     "    import seaborn\n",
-    "    grid = cube.to.distribution(mdims=['realization', 'time']).grid()\n",
+    "    grid = dataset.to.distribution(mdims=['realization', 'time']).grid()\n",
     "except:\n",
     "    grid = None\n",
     "grid"
@@ -242,7 +250,7 @@
     "\n",
     "### Selecting slices\n",
     "\n",
-    "Using the ``select`` method we can easily select ranges of coordinates in the Cube. The select method does not however know that latitude and longitude are cyclic, so instead we can select regions at both ends of the prime meridian (0$^\\circ$ longitude) and overlay them. In this way we can stitch together multiple cubes or simply view specific subregions:"
+    "Using the ``select`` method we can easily select ranges of coordinates in the dataset. The select method does not however know that latitude and longitude are cyclic, so instead we can select regions at both ends of the prime meridian (0$^\\circ$ longitude) and overlay them. In this way we can stitch together multiple cubes or simply view specific subregions:"
    ]
   },
   {
@@ -253,10 +261,9 @@
    },
    "outputs": [],
    "source": [
-    "northern = cube.select(latitude=(25, 75))\n",
+    "northern = dataset.select(latitude=(25, 75))\n",
     "(northern.select(longitude=(260, 305)).to(gv.Image, geo_dims) *\n",
-    " northern.select(longitude=(350, 360)).to(gv.Image, geo_dims) *\n",
-    " northern.select(longitude=(0, 50)).to(gv.Image, geo_dims) *\n",
+    " northern.select(longitude=(330, 362)).to(gv.Image, geo_dims) *\n",
     " coastline)[::5, ::5]"
    ]
   },
@@ -278,16 +285,16 @@
    "outputs": [],
    "source": [
     "%opts NdOverlay [xrotation=25 aspect=2  legend_position='right' legend_cols=2] Curve (color=Palette('Set1'))\n",
-    "cube.select(latitude=0, longitude=0).to(hv.Curve, ['time']).reindex().overlay()"
+    "dataset.select(latitude=0, longitude=0).to(hv.Curve, ['time']).reindex().overlay()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Collapsing coordinates\n",
+    "### Aggregating coordinates\n",
     "\n",
-    "Alternatively, we can collapse specific coordinates on the Iris cube first, then wrap it in a Dataset and convert it to curves indexed over time, which we can again overlay:"
+    "Another option is to aggregate over certain dimensions, in this way we can get an idea of distributions of temperatures across all latitudes and longitudes. Here we compute the mean temperature and standard deviation by latitude and longitude and cast the resulting collapsed view to a Spread Element:"
    ]
   },
   {
@@ -298,20 +305,16 @@
    },
    "outputs": [],
    "source": [
-    "for dim in ['longitude', 'latitude']:\n",
-    "    if cube.data.coord(dim).bounds is None:\n",
-    "        cube.data.coord(dim).guess_bounds()\n",
-    "\n",
-    "grid_weights = iris.analysis.cartography.area_weights(cube.data)\n",
-    "collapsed_cube = cube.data.collapsed(['longitude', 'latitude'], iris.analysis.MEAN, weights=grid_weights)\n",
-    "hv.Dataset(collapsed_cube).to(hv.Curve, 'time').overlay()"
+    "%output size=100\n",
+    "hv.Spread(dataset.aggregate('latitude', np.mean, np.std)) +\\\n",
+    "hv.Spread(dataset.aggregate('longitude', np.mean, np.std))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, it is very simple to select precisely which aspects of a complex, multidimensional Iris cube that you want to focus on."
+    "As you can see, it is very simple to select precisely which aspects of a complex, multidimensional datasets that you want to focus on."
    ]
   }
  ],

--- a/doc/Homepage.ipynb
+++ b/doc/Homepage.ipynb
@@ -49,9 +49,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "GeoViews is designed to work well with the [Iris](http://scitools.org.uk/iris) library for storing and processing climate and weather data, extracting the data and metadata from Iris [cubes](http://scitools.org.uk/iris/docs/latest/userguide/iris_cubes.html) for use in `GeoElement`s.  GeoViews can also use multidimensional [xarray](http://xarray.pydata.org) data, as well as NumPy arrays and Pandas data frames.  In each case, the data can be left stored in its original, native format, wrapped in a HoloViews or GeoViews object that provides instant interactive visualizations.\n",
+    "GeoViews is designed to work well with the [Iris](http://scitools.org.uk/iris) and [xarray](http://xarray.pydata.org)  libraries for working with multidimensional arrays, such as those stored in netCDF files.  GeoViews also accepts data as NumPy arrays and Pandas data frames.  In each case, the data can be left stored in its original, native format, wrapped in a HoloViews or GeoViews object that provides instant interactive visualizations.\n",
     "\n",
-    "The following example loads a dataset originally taken from [iris-sample-data](https://github.com/SciTools/iris-sample-data) and quickly builds an interactive tool for exploring the data:"
+    "The following example loads a dataset originally taken from [iris-sample-data](https://github.com/SciTools/iris-sample-data) and quickly builds an interactive tool for exploring how the data changes over time:"
    ]
   },
   {

--- a/doc/Homepage.ipynb
+++ b/doc/Homepage.ipynb
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "%%opts Image [colorbar=True] (cmap='viridis') Overlay [fig_size=200]\n",
-    "ensemble = xr.open_dataset('ensemble.nc')\n",
+    "ensemble = xr.open_dataset('./sample-data/ensemble.nc')\n",
     "dataset = gv.Dataset(ensemble, crs=crs.PlateCarree())\n",
     "dataset.to(gv.Image, ['longitude', 'latitude'], ['surface_temperature'], ['time']) * gv.Feature(cf.COASTLINE)"
    ]

--- a/doc/Homepage.ipynb
+++ b/doc/Homepage.ipynb
@@ -21,6 +21,7 @@
    "source": [
     "import holoviews as hv\n",
     "import geoviews as gv\n",
+    "import xarray as xr\n",
     "from cartopy import crs\n",
     "from cartopy import feature as cf\n",
     "\n",
@@ -50,7 +51,7 @@
    "source": [
     "GeoViews is designed to work well with the [Iris](http://scitools.org.uk/iris) library for storing and processing climate and weather data, extracting the data and metadata from Iris [cubes](http://scitools.org.uk/iris/docs/latest/userguide/iris_cubes.html) for use in `GeoElement`s.  GeoViews can also use multidimensional [xarray](http://xarray.pydata.org) data, as well as NumPy arrays and Pandas data frames.  In each case, the data can be left stored in its original, native format, wrapped in a HoloViews or GeoViews object that provides instant interactive visualizations.\n",
     "\n",
-    "The following example loads a cube from [iris-sample-data](https://github.com/SciTools/iris-sample-data) and quickly builds an interactive tool for exploring the data:"
+    "The following example loads a dataset originally taken from [iris-sample-data](https://github.com/SciTools/iris-sample-data) and quickly builds an interactive tool for exploring the data:"
    ]
   },
   {
@@ -62,9 +63,9 @@
    "outputs": [],
    "source": [
     "%%opts Image [colorbar=True] (cmap='viridis') Overlay [fig_size=200]\n",
-    "import iris\n",
-    "surface_temp = iris.load_cube(iris.sample_data_path('GloSea4', 'ensemble_001.pp'))\n",
-    "hv.Dataset(surface_temp).to(gv.Image, ['longitude', 'latitude']) * gv.Feature(cf.COASTLINE)"
+    "ensemble = xr.open_dataset('ensemble.nc')\n",
+    "dataset = gv.Dataset(ensemble, crs=crs.PlateCarree())\n",
+    "dataset.to(gv.Image, ['longitude', 'latitude'], ['surface_temperature'], ['time']) * gv.Feature(cf.COASTLINE)"
    ]
   }
  ],

--- a/doc/Projections.ipynb
+++ b/doc/Projections.ipynb
@@ -34,8 +34,8 @@
    "outputs": [],
    "source": [
     "%%output size=400\n",
-    "feats = [cf.LAND, cf.OCEAN, cf.RIVERS, cf.LAKES, cf.BORDERS, cf.COASTLINE]\n",
-    "features = hv.Overlay([gv.Feature(feature) for feature in feats])\n",
+    "cartopy_features = [cf.LAND, cf.OCEAN, cf.RIVERS, cf.LAKES, cf.BORDERS, cf.COASTLINE]\n",
+    "features = hv.Overlay([gv.Feature(feature) for feature in cartopy_features])\n",
     "features"
    ]
   },
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below is the full list of cartopy projections that can be displayed using matplotlib."
+    "The Bokeh backend currently only supports one output projection (web Mercator), but with the matplotlib backend you can choose between any of the available cartopy projections:"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(`crs.TransverseMercator` and `crs.Stereographic` can also be used, but currently generate warnings.)  We can test the different projections by creating a Layout of ``Feature`` elements, each with a different projection:"
+    "(`crs.TransverseMercator` and `crs.Stereographic` can also be used, but currently generate warnings.)  We can test the different projections by creating a HoloViews Layout of ``Feature`` elements, each with a different projection:"
    ]
   },
   {
@@ -85,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To change the projection we can use the call method on HoloViews objects and set it as a plot option.  In this way we can easily compose plots with different projections:"
+    "To change the output projection for a single HoloViews object, we can use the call method and set the projection as a plot option.  In this way we can easily compose plots with different output projections:"
    ]
   },
   {
@@ -108,7 +108,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Setting the output projection in this way will currently work only with the Matplotlib backend.  The Bokeh backend supports different projections for incoming data (via the `crs` parameter of most GeoViews objects), but the output projection will currently always be web Mercator."
+    "Setting the output projection in this way will currently work only with the Matplotlib backend, because Bokeh only supports web Mercator output, but both backends can use incoming data in any of the supported projections, via the `crs` parameter of most GeoViews objects."
    ]
   }
  ],

--- a/doc/Working_with_Bokeh.ipynb
+++ b/doc/Working_with_Bokeh.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In most GeoViews examples, we have selected the matplotlib plotting backend, because it has general support for projecting data to different geographic projections using cartopy. The Bokeh backend offers more advanced tools to interactively explore data, but is currently restricted to displaying data in web Mercator coordinates. Luckily, cartopy makes it possible to project points, geometries and even images from arbitrary coordinate systems into web Mercator so that they can be rendered by Bokeh. So as long as you choose the web Mercator format for your output, you should be able to use Bokeh for any of the  GeoViews examples from other notebooks. Bokeh also provides a general interface to render web-based map tile sources, making it simple to overlay your plots onto map tiles."
+    "In most GeoViews examples, we have selected the matplotlib plotting backend, because it has general support for projecting data to different geographic projections using cartopy. The Bokeh backend offers much more advanced tools to interactively explore data, but is currently restricted to displaying data in web Mercator coordinates. Luckily, cartopy makes it possible to project points, geometries and even images from arbitrary coordinate systems into web Mercator so that they can be rendered by Bokeh. So as long as you choose the web Mercator format for your output (or don't specify the output format), you should be able to use Bokeh for any of the GeoViews examples from other notebooks. Bokeh also provides a general interface to render web-based map tile sources, making it simple to overlay your plots onto map tiles."
    ]
   },
   {
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When using the matplotlib backend, the ``gv.WMTS`` element accepts tile source URLs valid for cartopy. When using the Bokeh backend, you will need to first wrap the URL into a ``WMTSTileSource`` object, because Bokeh's tile support uses a different URL format. Here we provide a list of common tile sources for use with Bokeh, and additional open tile sources you could use can be found at [openstreetmap.org](http://wiki.openstreetmap.org/wiki/Tile_servers)."
+    "When using the matplotlib backend, the ``gv.WMTS`` element accepts tile source URLs valid for cartopy. When using the Bokeh backend, you will need to first wrap the URL into a ``WMTSTileSource`` object, because Bokeh's tile support uses a different URL format. Here we provide a list of common tile sources for use with Bokeh. Additional open tile sources you could use can be found at [openstreetmap.org](http://wiki.openstreetmap.org/wiki/Tile_servers)."
    ]
   },
   {
@@ -64,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can lay these Elements out in an NdLayout by wrapping each ``WMTSTileSource`` in a ``WMTS`` Element and specifying both the extent and the coordinate reference system of these extents. Note that the extents are only required when displaying the tile source on its own; when it is overlaid with some data the data determines the extent."
+    "Now we can lay these Elements out in an NdLayout by wrapping each ``WMTSTileSource`` in a ``WMTS`` Element and specifying both the extent and the coordinate reference system of these extents. Note that the extents are only required when displaying the tile source on its own; when it is overlaid with some data the data determines the extent automatically."
    ]
   },
   {
@@ -198,7 +198,7 @@
     "collapsed": true
    },
    "source": [
-    "The Bokeh backend also provides basic support for working with images. In this example we will load a very simple Iris Cube and display it overlaid with the coastlines feature from Cartopy. Note that the Bokeh backend does not project the image directly into the web Mercator projection, instead relying on regridding, i.e. resampling the data using a new grid. This means the actual display may be subtly different from the more powerful matplotlib backend, which will project each of the pixels into the chosen display coordinate system without regridding."
+    "The Bokeh backend also provides basic support for working with images. In this example we will load a very simple Iris Cube and display it overlaid with the coastlines feature from Cartopy. Note that the Bokeh backend does not project the image directly into the web Mercator projection, instead relying on regridding, i.e. resampling the data using a new grid. This means the actual display may be subtly different from the more powerful image support for the matplotlib backend, which will project each of the pixels into the chosen display coordinate system without regridding."
    ]
   },
   {

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,7 +35,7 @@ bug reports and feature requests on our
    Home <self>
    Geometries <Projections>
    Geometries <Geometries>
-   Working with Iris I <Iris_Datasets_I>
-   Working with Iris II <Iris_Datasets_II>
+   Working with Gridded Data I <Gridded_Datasets_I>
+   Working with Gridded Data II <Gridded_Datasets_II>
    Working with Bokeh <Working_with_Bokeh>
    Github source <https://github.com/ioam/geoviews>

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -1,5 +1,9 @@
 import os, glob
+import requests
+from io import BytesIO
 from shutil import copyfile
+from zipfile import ZipFile
+
 import param
 
 from .element import (_Element, Feature, Tiles,     # noqa (API import)
@@ -11,10 +15,13 @@ from . import plotting                              # noqa (API import)
 __version__ = param.Version(release=(1,0,0), fpath=__file__,
                             commit="$Format:%h$", reponame='geoviews')
 
+SAMPLE_DATA_URL = 'http://assets.holoviews.org/geoviews-sample-data.zip'
 
-def examples(path='geoviews-examples', verbose=False):
+
+def examples(path='geoviews-examples', include_data=False, verbose=False):
     """
-    Copies the examples to the supplied path.
+    Copies the example notebooks to the supplied path. If
+    include_data is enabled the sample data is also downloaded.
     """
 
     import os, glob
@@ -38,3 +45,30 @@ def examples(path='geoviews-examples', verbose=False):
                 if verbose:
                     print("%s copied to %s" % (nb_name, path))
             break
+
+    if include_data:
+        data_path = os.path.join(path, 'sample-data')
+        sample_data(data_path, verbose)
+
+
+def sample_data(path='../doc/sample-data', verbose=False):
+    """
+    Downloads and unzips the sample data to a particular location.
+    """
+    url = requests.get(SAMPLE_DATA_URL)
+    zipfile = ZipFile(BytesIO(url.content))
+    zip_names = zipfile.namelist()
+
+    path = os.path.abspath(path)
+    if not os.path.exists(path):
+        os.makedirs(path)
+        if verbose:
+            print('Created directory %s' % path)
+
+    for nc_file in zip_names:
+        extracted_file = zipfile.open(nc_file).read()
+        save_path = os.path.join(path, nc_file)
+        with open(save_path, 'wb') as f:
+            f.write(extracted_file)
+        if verbose:
+            print("%s downloaded to %s" % (nc_file, path))

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -23,10 +23,6 @@ def examples(path='geoviews-examples', include_data=False, verbose=False):
     Copies the example notebooks to the supplied path. If
     include_data is enabled the sample data is also downloaded.
     """
-
-    import os, glob
-    from shutil import copytree, ignore_patterns
-
     candidates = [os.path.join(__path__[0], '../doc/'),
                   os.path.join(__path__[0], '../../../../share/geoviews-examples')]
 

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -11,20 +11,30 @@ from . import plotting                              # noqa (API import)
 __version__ = param.Version(release=(1,0,0), fpath=__file__,
                             commit="$Format:%h$", reponame='geoviews')
 
-def examples(path='.', verbose=False):
+
+def examples(path='geoviews-examples', verbose=False):
     """
-    Copies the example Jupyter notebooks to the supplied path.
+    Copies the examples to the supplied path.
     """
+
+    import os, glob
+    from shutil import copytree, ignore_patterns
+
+    candidates = [os.path.join(__path__[0], '../doc/'),
+                  os.path.join(__path__[0], '../../../../share/geoviews-examples')]
+
     path = os.path.abspath(path)
     if not os.path.exists(path):
         os.makedirs(path)
         if verbose:
             print('Created directory %s' % path)
-    notebook_glob = os.path.join(__path__[0], '..', 'doc', '*.ipynb')
-    notebooks = glob.glob(notebook_glob)
-    for notebook in notebooks:
-        nb_path = os.path.join(path, os.path.basename(notebook))
-        copyfile(notebook, nb_path)
-        if verbose:
-            print("%s copied to %s" % (os.path.basename(notebook), path))
 
+    for source in candidates:
+        if os.path.exists(source):
+            for nb in glob.glob(os.path.join(source, '*.ipynb')):
+                nb_name = os.path.basename(nb)
+                nb_path = os.path.join(path, nb_name)
+                copyfile(nb, nb_path)
+                if verbose:
+                    print("%s copied to %s" % (nb_name, path))
+            break

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -1,7 +1,7 @@
 import os, glob
 import requests
 from io import BytesIO
-from shutil import copyfile
+from shutil import copyfile, copytree
 from zipfile import ZipFile
 
 import param
@@ -27,6 +27,7 @@ def examples(path='geoviews-examples', include_data=False, verbose=False):
                   os.path.join(__path__[0], '../../../../share/geoviews-examples')]
 
     path = os.path.abspath(path)
+    asset_path = os.path.join(path, 'assets')
     if not os.path.exists(path):
         os.makedirs(path)
         if verbose:
@@ -34,6 +35,10 @@ def examples(path='geoviews-examples', include_data=False, verbose=False):
 
     for source in candidates:
         if os.path.exists(source):
+            if not os.path.exists(asset_path):
+                copytree(os.path.join(source, 'assets'), asset_path)
+                if verbose:
+                    print('Copied assets to %s' % asset_path)
             for nb in glob.glob(os.path.join(source, '*.ipynb')):
                 nb_name = os.path.basename(nb)
                 nb_path = os.path.join(path, nb_name)


### PR DESCRIPTION
Completely overhauls the existing Tutorials to use netCDF data files (exported from iris-sample-data), which can be loaded with either xarray or iris. Still need to define a good way to grab the data from http://assets.holoviews.org/geoviews-sample-data.zip and get a few PRs in HoloViews committed and merged.
