### PR TITLE
Added default features

### DIFF
--- a/doc/Geometries.ipynb
+++ b/doc/Geometries.ipynb
@@ -12,9 +12,10 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "import geoviews as gv\n",
+    "import geoviews.feature as gf\n",
     "import cartopy\n",
+    "import cartopy.feature as cf\n",
     "from cartopy import crs as ccrs\n",
-    "from cartopy import feature as cf\n",
     "hv.notebook_extension()\n",
     "%output dpi=120"
    ]
@@ -27,7 +28,7 @@
     "\n",
     "### Feature\n",
     "\n",
-    "The Feature Element provides a very convenient means of overlaying a set of basic geographic features on top of or behind a plot. The ``cartopy.feature`` module, which we have imported as ``cf``, provides basic geographic features such as coastlines, country borders, and land masses. Here we demonstrate how we can plot these very easily, either in isolation or overlaid:"
+    "The Feature Element provides a very convenient means of overlaying a set of basic geographic features on top of or behind a plot. The ``cartopy.feature`` module provides various ways of loading custom features, however geoviews provides a number of default features which we have imported as ``gf``, amongst others this includes coastlines, country borders, and land masses. Here we demonstrate how we can plot these very easily, either in isolation or overlaid:"
    ]
   },
   {
@@ -38,12 +39,30 @@
    },
    "outputs": [],
    "source": [
-    "%opts Overlay [show_grid=False] Layout [hspace=0.2 sublabel_position=(-.15, .7)]\n",
-    "coasts  = gv.Feature(cf.COASTLINE)\n",
-    "borders = gv.Feature(cf.BORDERS)\n",
-    "land    = gv.Feature(cf.LAND)\n",
-    "\n",
-    "land + borders + land*borders"
+    "(gf.ocean + gf.land + gf.ocean * gf.land * gf.coastline * gf.borders).cols(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These deafult features simply wrap around cartopy Features, therefore we can easily load a custom ``NaturalEarthFeature`` such as graticules at 30 degree intervals: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Feature.Lines [projection=ccrs.Robinson()] (facecolor='none' edgecolor='gray')\n",
+    "states_provinces = cf.NaturalEarthFeature(\n",
+    "    category='physical',\n",
+    "    name='graticules_30',\n",
+    "    scale='110m')\n",
+    "(gf.ocean * gf.land() * gv.Feature(states_provinces, group='Lines') * gf.borders * gf.coastline)"
    ]
   },
   {
@@ -63,7 +82,7 @@
    },
    "outputs": [],
    "source": [
-    "land_geoms = list(cf.LAND.geometries())\n",
+    "land_geoms = list(gf.land.data.geometries())\n",
     "land_geoms[21]"
    ]
   },

--- a/doc/Gridded_Datasets_I.ipynb
+++ b/doc/Gridded_Datasets_I.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "GeoViews is designed to make full use of multidimensional gridded datasets stored in netCDF or other common formats, via the xarray and iris interfaces in HoloViews. This notebook will demonstrate how to load data using both of these data backends, along with some of their individual quirks. The data used in this notebook was originally shipped as part of the [``SciTools/iris-sample-data``](https://github.com/SciTools/iris-sample-data) repository, but a smaller netCDF file is included as part of the GeoViews so that it can be used with xarray as well."
+    "GeoViews is designed to make full use of data gridded datasets stored as array based data in netCDF or other common formats via the xarray and iris interfaces in HoloViews. This notebook will demonstrate how to load data using both of these data backends and some of their individual quirks. The data used in this notebook was originally shipped as part of the [``SciTools/iris-sample-data``](https://github.com/SciTools/iris-sample-data) repository, but a smaller netCDF file is included as part of the GeoViews."
    ]
   },
   {
@@ -20,8 +20,9 @@
     "import xarray as xr\n",
     "import holoviews as hv\n",
     "import geoviews as gv\n",
+    "import geoviews.feature as gf\n",
     "from cartopy import crs\n",
-    "from cartopy import feature as cf\n",
+    "\n",
     "hv.notebook_extension()"
    ]
   },
@@ -54,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see that it is easy to set global defaults for a project, allowing any suitable settings to be made into a default on a per-element-type basis. Now let's specify the maximum number of frames we will be displaying:"
+    "Note that it is easy to set global defaults for a project, allowing any suitable settings to be made into a default on a per-element-type basis. Now let's specify the maximum number of frames we will be displaying:"
    ]
   },
   {
@@ -87,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we will primarily be working with xarray, but we will also load the same data using iris so that we can demonstrate that the two data backends are nearly equivalent.\n",
+    "In this notebook we will primarily be working with xarray, however to demonstrate that iris and xarray are basically equivalent we will load the same dataset using both backends.\n",
     "\n",
     "#### XArray\n",
     "\n",
@@ -132,9 +133,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Describing the differences between these two libraries is well beyond the scope of this tutorial, but you can see from the summaries that the two libraries deal differently with both the bounds and with the actual data variables. Iris cubes support only a single data variable, while an xarray dataset can have any number of variables. In this case we are only interested in the ``surface_temperature`` dimension, indexed by ``longitude``, ``latitude`` and ``time``.\n",
+    "Describing the differences between these two libraries is well beyond the scope of this tutorial, but you will notice from the summaries that the two libraries deal differently with both the bounds and with the actual data variables. Iris cubes support only a single data variable, while an xarray dataset can have any number of variables. In this case we are only interested in the ``surface_temperature`` dimension, indexed by ``longitude``, ``latitude`` and ``time``.\n",
     "\n",
-    "We can easily express this interest by wrapping the data in a GeoViews ``Dataset`` Element and declaring the key dimensions (``kdims``) and value dimensions (``vdims``). Note that the Iris interface is much smarter in the way it extracts the dimensions, so usually you will not have to supply them explicitly."
+    "We can easily express this by wrapping the data in a GeoViews ``Dataset`` Element and declaring the key dimensions (``kdims``) and value dimensions (``vdims``). Note that the Iris interface is much smarter in the way it extracts the dimensions so usually you will not have to supply them explicitly."
    ]
   },
   {
@@ -175,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Despite appearing identical, there are some internal differences, such as in the data types. xarray uses NumPy datetime64 types for dates, while iris will use simple floats:"
+    "They now appear identical, however there are some differences between these two, specifically the types are not necessarily consistent. Here we can see that xarray uses NumPy datetime64 types for dates while iris will use simple floats:"
    ]
   },
   {
@@ -195,7 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To improve the formatting of dates on the xarray dataset, we can set the formatter for datetime64 types:"
+    "To improve the formatting of dates on the xarray dataset we can set the formatter for datetime64 types:"
    ]
   },
   {
@@ -213,9 +214,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The other major differences in the way iris cubes are handled are in deducing various bits of metadata including the coordinate system, units, and formatters. Otherwise the two Dataset Elements will behave largely the same.\n",
+    "The other major differences in the way iris cubes are handled are in deducing various bits of metadata including the coordinate system, units and formatters. Otherwise the two Dataset Elements will behave largely the same.\n",
     "\n",
-    "For either data backend, the `Dataset` object is not yet visualizable, because we have not chosen which dimensions to map onto which axes of a plot.\n",
+    "However, in this form the `Dataset` is not yet visualizable, because we have not chosen which dimensions to map onto which axes of a plot.\n",
     "\n",
     "# A Simple example\n",
     "\n",
@@ -231,6 +232,13 @@
    "outputs": [],
    "source": [
     "xr_dataset.to(gv.Image, ['longitude', 'latitude'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice how we also had to specify the coordinate reference system (``crs``). This is because xarray does not extract a coordinate system from the data. Iris on the other hand makes that information available automatically, which means we don't have to declare it explicitly:"
    ]
   },
   {
@@ -287,7 +295,6 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Layout [fig_inches=(12,3.5)]\n",
     "(xr_dataset.to.image(['longitude', 'latitude'])+\n",
     " air_temperature.to.image(['longitude', 'latitude']))"
    ]
@@ -296,9 +303,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The above plot shows how to combine a fixed number of plots using ``+``, but what if you want to combine some arbitrarily long list of objects?  You can do that by making a ``Layout`` explicitly, which is what ``+`` does internally.\n",
+    "Next is a fairly involved example that plots an arbitrary number of HoloViews objects side by side in a ``Layout``, rather than using the fixed-layout ``+`` operator. \n",
     "\n",
-    "The following more complicated example shows how complex interactive plots can be generated with relatively little code, and also demonstrates how different HoloViews elements can be combined together. In the following visualization, the black dot denotes a specific longitude, latitude location *(0,10)*, and the curve is a sample of the ``surface_temperature`` at that location.  The curve is unaffected by the `time` slider because it already lays out time along the x axis:"
+    "This example shows how complex interactive plots can be generated with relatively little code, and also demonstrates how different HoloViews elements can be combined together. In the following visualization, the curve is a sample of the ``surface_temperature`` at longitude and latitude *(0,10)*, and it is unaffected by the `time` slider because it already lays out time along the x axis:"
    ]
   },
   {
@@ -309,9 +316,11 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Layout [fig_inches=(12,7)] Curve [xticks=4 xrotation=15] Points (color='k')\n",
+    "%%opts Curve [aspect=2 xticks=4 xrotation=15] Points (color='k')\n",
+    "#%%opts Image [projection=crs.PlateCarree()]\n",
     "\n",
     "temp_curve = hv.Curve(xr_dataset.select(longitude=0, latitude=10), kdims=['time'])\n",
+    "\n",
     "temp_maps = [cb.to(gv.Image,['longitude', 'latitude']) * gv.Points([(0,10)], crs=crs.PlateCarree()) \n",
     "             for cb in [xr_dataset, air_temperature]]\n",
     "\n",
@@ -341,7 +350,7 @@
    "outputs": [],
    "source": [
     "%%opts Image [projection=crs.Geostationary()] (cmap='Greens') Overlay [xaxis=None yaxis=None]\n",
-    "xr_dataset.to.image(['longitude', 'latitude']) * gv.Feature(cf.COASTLINE)"
+    "xr_dataset.to.image(['longitude', 'latitude']) * gf.coastline"
    ]
   },
   {
@@ -364,8 +373,8 @@
     "%%opts Image [projection=crs.Geostationary()] (cmap='Greens') Overlay [xaxis=None yaxis=None]\n",
     "max_surface_temp = xr_dataset.range('surface_temperature')[1]\n",
     "print max_surface_temp\n",
-    "xr_dataset.redim(surface_temperature=dict(range=(300, max_surface_temp))).\\\n",
-    "  to(gv.Image,['longitude', 'latitude']) * gv.Feature(cf.COASTLINE)"
+    "xr_dataset.redim(surface_temperature=dict(range=(300, max_surface_temp))).to(gv.Image,['longitude', 'latitude']) \\\n",
+    "  * gf.coastline"
    ]
   },
   {
@@ -390,14 +399,14 @@
    },
    "outputs": [],
    "source": [
-    "xr_dataset.to(gv.FilledContours,['longitude', 'latitude']) * gv.Feature(cf.COASTLINE)"
+    "xr_dataset.to(gv.FilledContours,['longitude', 'latitude']) * gf.coastline"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, it's quite simple to expose any data you like from your Iris cube or xarray, easily and flexibly creating interactive or static visualizations."
+    "As you can see, it's quite simple to expose any data you like from your Iris cube, easily and flexibly creating interactive or static visualizations."
    ]
   }
  ],

--- a/doc/Gridded_Datasets_I.ipynb
+++ b/doc/Gridded_Datasets_I.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "GeoViews is designed to make full use of data gridded datasets stored as array based data in netCDF or other common formats via the xarray and iris interfaces in HoloViews. This notebook will demonstrate how to load data using both of these data backends and some of their individual quirks. The data used in this notebook was originally shipped as part of the [``SciTools/iris-sample-data``](https://github.com/SciTools/iris-sample-data) repository, but a smaller netCDF file is included as part of the GeoViews."
+    "GeoViews is designed to make full use of multidimensional gridded datasets stored in netCDF or other common formats, via the xarray and iris interfaces in HoloViews. This notebook will demonstrate how to load data using both of these data backends, along with some of their individual quirks. The data used in this notebook was originally shipped as part of the [``SciTools/iris-sample-data``](https://github.com/SciTools/iris-sample-data) repository, but a smaller netCDF file is included as part of the GeoViews so that it can be used with xarray as well."
    ]
   },
   {
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that it is easy to set global defaults for a project, allowing any suitable settings to be made into a default on a per-element-type basis. Now let's specify the maximum number of frames we will be displaying:"
+    "You can see that it is easy to set global defaults for a project, allowing any suitable settings to be made into a default on a per-element-type basis. Now let's specify the maximum number of frames we will be displaying:"
    ]
   },
   {
@@ -88,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we will primarily be working with xarray, however to demonstrate that iris and xarray are basically equivalent we will load the same dataset using both backends.\n",
+    "In this notebook we will primarily be working with xarray, but we will also load the same data using iris so that we can demonstrate that the two data backends are nearly equivalent.\n",
     "\n",
     "#### XArray\n",
     "\n",
@@ -133,9 +133,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Describing the differences between these two libraries is well beyond the scope of this tutorial, but you will notice from the summaries that the two libraries deal differently with both the bounds and with the actual data variables. Iris cubes support only a single data variable, while an xarray dataset can have any number of variables. In this case we are only interested in the ``surface_temperature`` dimension, indexed by ``longitude``, ``latitude`` and ``time``.\n",
+    "Describing the differences between these two libraries is well beyond the scope of this tutorial, but you can see from the summaries that the two libraries deal differently with both the bounds and with the actual data variables. Iris cubes support only a single data variable, while an xarray dataset can have any number of variables. In this case we are only interested in the ``surface_temperature`` dimension, indexed by ``longitude``, ``latitude`` and ``time``.\n",
     "\n",
-    "We can easily express this by wrapping the data in a GeoViews ``Dataset`` Element and declaring the key dimensions (``kdims``) and value dimensions (``vdims``). Note that the Iris interface is much smarter in the way it extracts the dimensions so usually you will not have to supply them explicitly."
+    "We can easily express this interest by wrapping the data in a GeoViews ``Dataset`` Element and declaring the key dimensions (``kdims``) and value dimensions (``vdims``). Note that the Iris interface is much smarter in the way it extracts the dimensions, so usually you will not have to supply them explicitly."
    ]
   },
   {
@@ -176,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "They now appear identical, however there are some differences between these two, specifically the types are not necessarily consistent. Here we can see that xarray uses NumPy datetime64 types for dates while iris will use simple floats:"
+    "Despite appearing identical, there are some internal differences, such as in the data types. xarray uses NumPy datetime64 types for dates, while iris will use simple floats:"
    ]
   },
   {
@@ -214,9 +214,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The other major differences in the way iris cubes are handled are in deducing various bits of metadata including the coordinate system, units and formatters. Otherwise the two Dataset Elements will behave largely the same.\n",
+    "The other major differences in the way iris cubes are handled are in deducing various bits of metadata including the coordinate system, units, and formatters. Otherwise the two Dataset Elements will behave largely the same.\n",
     "\n",
-    "However, in this form the `Dataset` is not yet visualizable, because we have not chosen which dimensions to map onto which axes of a plot.\n",
+    "For either data backend, the `Dataset` object is not yet visualizable, because we have not chosen which dimensions to map onto which axes of a plot.\n",
     "\n",
     "# A Simple example\n",
     "\n",
@@ -303,9 +303,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next is a fairly involved example that plots an arbitrary number of HoloViews objects side by side in a ``Layout``, rather than using the fixed-layout ``+`` operator. \n",
+    "The above plot shows how to combine a fixed number of plots using ``+``, but what if you want to combine some arbitrarily long list of objects?  You can do that by making a ``Layout`` explicitly, which is what ``+`` does internally.\n",
     "\n",
-    "This example shows how complex interactive plots can be generated with relatively little code, and also demonstrates how different HoloViews elements can be combined together. In the following visualization, the curve is a sample of the ``surface_temperature`` at longitude and latitude *(0,10)*, and it is unaffected by the `time` slider because it already lays out time along the x axis:"
+    "The following more complicated example shows how complex interactive plots can be generated with relatively little code, and also demonstrates how different HoloViews elements can be combined together. In the following visualization, the black dot denotes a specific longitude, latitude location *(0,10)*, and the curve is a sample of the ``surface_temperature`` at that location.  The curve is unaffected by the `time` slider because it already lays out time along the x axis:"
    ]
   },
   {
@@ -317,8 +317,6 @@
    "outputs": [],
    "source": [
     "%%opts Curve [aspect=2 xticks=4 xrotation=15] Points (color='k')\n",
-    "#%%opts Image [projection=crs.PlateCarree()]\n",
-    "\n",
     "temp_curve = hv.Curve(xr_dataset.select(longitude=0, latitude=10), kdims=['time'])\n",
     "\n",
     "temp_maps = [cb.to(gv.Image,['longitude', 'latitude']) * gv.Points([(0,10)], crs=crs.PlateCarree()) \n",
@@ -406,7 +404,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, it's quite simple to expose any data you like from your Iris cube, easily and flexibly creating interactive or static visualizations."
+    "As you can see, it's quite simple to expose any data you like from your Iris cube or xarray, easily and flexibly creating interactive or static visualizations."
    ]
   }
  ],

--- a/doc/Gridded_Datasets_I.rst
+++ b/doc/Gridded_Datasets_I.rst
@@ -1,0 +1,4 @@
+Working with Gridded Data I
+===========================
+
+.. notebook:: geoviews Gridded_Datasets_I.ipynb

--- a/doc/Gridded_Datasets_II.ipynb
+++ b/doc/Gridded_Datasets_II.ipynb
@@ -12,8 +12,8 @@
     "import xarray as xr\n",
     "import holoviews as hv\n",
     "import geoviews as gv\n",
+    "import geoviews.feature as gf\n",
     "from cartopy import crs as ccrs\n",
-    "from cartopy import feature as cf\n",
     "\n",
     "hv.notebook_extension()\n",
     "%output size=200"
@@ -109,8 +109,7 @@
    "outputs": [],
    "source": [
     "geo_dims = ['longitude', 'latitude']\n",
-    "coastline = gv.Feature(cf.COASTLINE)\n",
-    "(dataset.to(gv.Image, geo_dims) * coastline)[::5, ::5]"
+    "(dataset.to(gv.Image, geo_dims) * gf.coastline)[::5, ::5]"
    ]
   },
   {
@@ -128,9 +127,8 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Layout [fig_inches=(4, 8)]\n",
     "%%opts Points [color_index=2 size_index=None] (cmap='jet')\n",
-    "hv.Layout([dataset.to(el, geo_dims)[::5, ::5] * coastline\n",
+    "hv.Layout([dataset.to(el, geo_dims)[::10, ::10] * gf.coastline\n",
     "           for el in [gv.FilledContours, gv.LineContours, gv.Points]]).cols(1)"
    ]
   },
@@ -149,7 +147,7 @@
    },
    "outputs": [],
    "source": [
-    "dataset.to(gv.Image, geo_dims, dynamic=True) * coastline"
+    "dataset.to(gv.Image, geo_dims, dynamic=True) * gf.coastline"
    ]
   },
   {
@@ -172,7 +170,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Curve [xrotation=25 aspect=2]\n",
+    "%%opts Curve [xrotation=25] NdOverlay [fig_size=200 aspect=1.2]\n",
     "dataset.to(hv.Curve, 'time', dynamic=True).overlay('realization')"
    ]
   },
@@ -267,7 +265,7 @@
     "northern = dataset.select(latitude=(25, 75))\n",
     "(northern.select(longitude=(260, 305)).to(gv.Image, geo_dims) *\n",
     " northern.select(longitude=(330, 362)).to(gv.Image, geo_dims) *\n",
-    " coastline)[::5, ::5]"
+    " gf.coastline)[::5, ::5]"
    ]
   },
   {

--- a/doc/Gridded_Datasets_II.rst
+++ b/doc/Gridded_Datasets_II.rst
@@ -1,0 +1,4 @@
+Working with Gridded Data II
+============================
+
+.. notebook:: geoviews Gridded_Datasets_II.ipynb

--- a/doc/Homepage.ipynb
+++ b/doc/Homepage.ipynb
@@ -21,9 +21,9 @@
    "source": [
     "import holoviews as hv\n",
     "import geoviews as gv\n",
+    "import geoviews.feature as gf\n",
     "import xarray as xr\n",
     "from cartopy import crs\n",
-    "from cartopy import feature as cf\n",
     "\n",
     "hv.notebook_extension()"
    ]
@@ -37,12 +37,7 @@
    "outputs": [],
    "source": [
     "%%opts Feature [projection=crs.Geostationary()]\n",
-    "\n",
-    "coasts  = gv.Feature(cf.COASTLINE)\n",
-    "borders = gv.Feature(cf.BORDERS)\n",
-    "ocean   = gv.Feature(cf.OCEAN)\n",
-    "\n",
-    "ocean + borders + (ocean*borders).relabel(\"Overlay\")"
+    "(gf.ocean + gf.land + gf.ocean * gf.land * gf.coastline * gf.borders).cols(3)"
    ]
   },
   {
@@ -65,7 +60,7 @@
     "%%opts Image [colorbar=True] (cmap='viridis') Overlay [fig_size=200]\n",
     "ensemble = xr.open_dataset('./sample-data/ensemble.nc')\n",
     "dataset = gv.Dataset(ensemble, crs=crs.PlateCarree())\n",
-    "dataset.to(gv.Image, ['longitude', 'latitude'], ['surface_temperature'], ['time']) * gv.Feature(cf.COASTLINE)"
+    "dataset.to(gv.Image, ['longitude', 'latitude'], ['surface_temperature'], ['time']) * gf.coastline()"
    ]
   }
  ],
@@ -75,18 +70,6 @@
    "display_name": "Python 2",
    "language": "python",
    "name": "python2"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
   },
   "widgets": {
    "state": {},

--- a/doc/Iris_Datasets_I.rst
+++ b/doc/Iris_Datasets_I.rst
@@ -1,4 +1,0 @@
-Working with Iris I
-===================
-
-.. notebook:: geoviews Iris_Datasets_I.ipynb

--- a/doc/Iris_Datasets_II.rst
+++ b/doc/Iris_Datasets_II.rst
@@ -1,4 +1,0 @@
-Working with Iris II
-====================
-
-.. notebook:: geoviews Iris_Datasets_II.ipynb

--- a/doc/Projections.ipynb
+++ b/doc/Projections.ipynb
@@ -12,9 +12,8 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "import geoviews as gv\n",
+    "import geoviews.feature as gf \n",
     "from cartopy import crs\n",
-    "from cartopy import feature as cf\n",
-    "\n",
     "hv.notebook_extension()"
    ]
   },
@@ -34,8 +33,7 @@
    "outputs": [],
    "source": [
     "%%output size=400\n",
-    "cartopy_features = [cf.LAND, cf.OCEAN, cf.RIVERS, cf.LAKES, cf.BORDERS, cf.COASTLINE]\n",
-    "features = hv.Overlay([gv.Feature(feature) for feature in cartopy_features])\n",
+    "features = hv.Overlay([gf.land, gf.ocean, gf.rivers, gf.lakes, gf.borders, gf.coastline])\n",
     "features"
    ]
   },
@@ -77,7 +75,7 @@
    },
    "outputs": [],
    "source": [
-    "hv.Layout([gv.Feature(cf.COASTLINE, group=p.__name__)(plot=dict(projection=p()))\n",
+    "hv.Layout([gf.coastline.relabel(group=p.__name__)(plot=dict(projection=p()))\n",
     "           for p in projections]).display('all')"
    ]
   },
@@ -97,11 +95,8 @@
    "outputs": [],
    "source": [
     "%output size=200\n",
-    "feats = [cf.LAND, cf.OCEAN, cf.RIVERS, cf.LAKES, cf.BORDERS, cf.COASTLINE]\n",
-    "features = hv.Overlay([gv.Feature(feature) for feature in feats])\n",
-    "\n",
-    "(features(plot=dict(projection=crs.Mollweide())) +\n",
-    "features.relabel(group='Geostationary Overlay')(plot=dict(projection=crs.Geostationary())))"
+    "(features.relabel(group='Mollweide')(plot=dict(projection=crs.Mollweide())) +\n",
+    "features.relabel(group='Geostationary')(plot=dict(projection=crs.Geostationary())))"
    ]
   },
   {

--- a/doc/Projections.rst
+++ b/doc/Projections.rst
@@ -1,0 +1,4 @@
+Projections
+===========
+
+.. notebook:: geoviews Projections.ipynb

--- a/doc/Working_with_Bokeh.ipynb
+++ b/doc/Working_with_Bokeh.ipynb
@@ -9,15 +9,15 @@
    },
    "outputs": [],
    "source": [
-    "import iris\n",
+    "import xarray as xr\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import holoviews as hv\n",
     "import geoviews as gv\n",
+    "import geoviews.feature as gf\n",
     "\n",
     "import cartopy\n",
     "from cartopy import crs as ccrs\n",
-    "from cartopy import feature as cf\n",
     "\n",
     "from bokeh.tile_providers import STAMEN_TONER\n",
     "from bokeh.models import WMTSTileSource\n",
@@ -126,7 +126,8 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Overlay [width=600 height=300 xaxis=None yaxis=None] Points (size=0.005 cmap='viridis') [tools=['hover'] color_index=2]\n",
+    "%%opts Overlay [width=600 height=300 xaxis=None yaxis=None] \n",
+    "%%opts Points (size=0.005 cmap='viridis') [tools=['hover'] color_index=2]\n",
     "(gv.WMTS(tiles['Wikipedia']) *\\\n",
     "population.to(gv.Points, kdims=['Longitude', 'Latitude'],\n",
     "              vdims=['Population', 'City', 'Country'], crs=ccrs.PlateCarree()))"
@@ -209,9 +210,12 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Overlay [width=600 height=400] Image (cmap='viridis')\n",
-    "surface_temp = iris.load_cube(iris.sample_data_path('air_temp.pp'))\n",
-    "hv.Dataset(surface_temp).to.image() * gv.Feature(cf.COASTLINE)"
+    "%%opts Overlay [width=600 height=400] Image (cmap='viridis') Feature (line_color='black')\n",
+    "dataset = xr.open_dataset('./sample-data/pre-industrial.nc')\n",
+    "air_temperature = gv.Dataset(dataset, kdims=['longitude', 'latitude'],\n",
+    "                             group='Pre-industrial air temperature', vdims=['air_temperature'],\n",
+    "                             crs=ccrs.PlateCarree())\n",
+    "air_temperature.to.image() * gf.coastline"
    ]
   },
   {

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,7 +33,7 @@ bug reports and feature requests on our
    :maxdepth: 2
 
    Home <self>
-   Geometries <Projections>
+   Projections <Projections>
    Geometries <Geometries>
    Working with Gridded Data I <Gridded_Datasets_I>
    Working with Gridded Data II <Gridded_Datasets_II>

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -10,6 +10,7 @@ from .element import (_Element, Feature, Tiles,     # noqa (API import)
                       WMTS, LineContours, FilledContours, Text, Image,
                       Points, Path, Polygons, Shape, Dataset)
 from . import plotting                              # noqa (API import)
+from . import feature                               # noqa (API import)
 
 
 __version__ = param.Version(release=(1,0,0), fpath=__file__,

--- a/geoviews/feature.py
+++ b/geoviews/feature.py
@@ -1,0 +1,10 @@
+from cartopy import feature as cf
+
+from .element import Feature
+
+borders   = Feature(cf.BORDERS, group='Borders')
+coastline = Feature(cf.COASTLINE, group='Coastline')
+land      = Feature(cf.LAND, group='Land')
+lakes     = Feature(cf.LAKES, group='Lakes')
+ocean     = Feature(cf.OCEAN, group='Ocean')
+rivers    = Feature(cf.RIVERS, group='Rivers')

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -218,5 +218,12 @@ Store.register({WMTS: TilePlot,
 options = Store.options(backend='bokeh')
 
 options.Feature = Options('style', line_color='black')
+options.Feature.Coastline = Options('style', line_width=0.5)
+options.Feature.Borders = Options('style', line_width=0.5)
+options.Feature.Rivers = Options('style', line_color='blue')
+options.Feature.Land   = Options('style', fill_color='#efefdb', line_color='#efefdb')
+options.Feature.Ocean  = Options('style', fill_color='#97b6e1', line_color='#97b6e1')
+options.Feature.Lakes  = Options('style', fill_color='#97b6e1', line_color='#97b6e1')
+options.Feature.Rivers = Options('style', line_color='#97b6e1')
 options.Shape = Options('style', line_color='black', fill_color='#30A2DA')
 

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -69,6 +69,13 @@ class LayoutPlot(ProjectionPlot, HvLayoutPlot):
     the correct projection for each axis.
     """
 
+    vspace = param.Number(default=0.3, doc="""
+      Specifies the space between vertically adjacent elements in the grid.
+      Default value is set conservatively to avoid overlap of subplots.""")
+
+    v17_layout_format = True
+
+
 
 class OverlayPlot(ProjectionPlot, HvOverlayPlot):
     """


### PR DESCRIPTION
Adds default features with same default styling for bokeh.

```python
import geoviews.feature as gf
```

```python
%%output backend='matplotlib' size=200
%%opts Overlay [projection=ccrs.GOOGLE_MERCATOR]
gf.ocean * gf.land * gf.coastline * gf.borders * gf.rivers * gf.lakes
```

![image](https://cloud.githubusercontent.com/assets/1550771/17839815/da7b5fbe-67eb-11e6-9028-e71192594bdc.png)

```python
%%output backend='bokeh' size=125
%%opts Overlay [xaxis=None yaxis=None show_grid=False]
gf.ocean * gf.land * gf.coastline * gf.borders * gf.rivers * gf.lakes
```

![image](https://cloud.githubusercontent.com/assets/1550771/17839879/042c94f2-67ee-11e6-9160-44bec283b5a1.png)
