### PR TITLE
Replaced references to hv.GridImage with hv.Image

### DIFF
--- a/doc/Working_with_Bokeh.ipynb
+++ b/doc/Working_with_Bokeh.ipynb
@@ -127,7 +127,7 @@
    "outputs": [],
    "source": [
     "%%opts Overlay [width=600 height=300 xaxis=None yaxis=None] \n",
-    "%%opts Points (size=0.005 cmap='viridis') [tools=['hover'] color_index=2]\n",
+    "%%opts Points (size=0.005 cmap='viridis') [tools=['hover'] size_index=2 color_index=2]\n",
     "(gv.WMTS(tiles['Wikipedia']) *\\\n",
     "population.to(gv.Points, kdims=['Longitude', 'Latitude'],\n",
     "              vdims=['Population', 'City', 'Country'], crs=ccrs.PlateCarree()))"

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -7,7 +7,7 @@ from cartopy.io.shapereader import Reader
 from holoviews.core import Element2D, Dimension, Dataset as HvDataset, NdOverlay
 from holoviews.core.util import basestring, pd
 from holoviews.element import (Text as HVText, Path as HVPath,
-                               Polygons as HVPolygons, GridImage)
+                               Polygons as HVPolygons, Image as HVImage)
 
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry import (MultiLineString, LineString,
@@ -181,7 +181,7 @@ class Points(Dataset):
     group = param.String(default='Points')
 
 
-class LineContours(_Element, GridImage):
+class LineContours(_Element, HVImage):
     """
     Contours represents a 2D array of some quantity with
     some associated coordinates, which may be discretized
@@ -203,7 +203,7 @@ class FilledContours(LineContours):
     group = param.String(default='FilledContours')
 
 
-class Image(_Element, GridImage):
+class Image(_Element, HVImage):
     """
     Image represents a 2D array of some quantity with
     some associated coordinates.


### PR DESCRIPTION
Now that hv.Image can now be used in place of hv.GridImage, GridImage is deprecated, so replace GridImage with Image here in geoviews.