### PR TITLE
Various updates for HoloViews 1.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ install:
     fi
   - pip install coveralls
   - pip install git+https://github.com/ioam/holoviews.git
-  - conda install -c scitools iris
-  - conda install -c scitools mo_pack
+  - conda install -c conda-forge iris cartopy xarray
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose numpy matplotlib bokeh pandas scipy jupyter ipython param freetype=2.5.2 flake8
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose numpy matplotlib bokeh pandas scipy jupyter ipython param freetype=2.5.2 flake8 mock filelock
   - source activate test-environment
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;

--- a/doc/Gridded_Datasets_I.ipynb
+++ b/doc/Gridded_Datasets_I.ipynb
@@ -150,7 +150,7 @@
     "vdims = ['surface_temperature']\n",
     "\n",
     "xr_dataset = gv.Dataset(xr_ensemble, kdims=kdims, vdims=vdims, crs=crs.PlateCarree())\n",
-    "iris_dataset = gv.Dataset(iris_ensemble)"
+    "iris_dataset = gv.Dataset(iris_ensemble, kdims=kdims, vdims=vdims)"
    ]
   },
   {
@@ -322,7 +322,7 @@
     "temp_maps = [cb.to(gv.Image,['longitude', 'latitude']) * gv.Points([(0,10)], crs=crs.PlateCarree()) \n",
     "             for cb in [xr_dataset, air_temperature]]\n",
     "\n",
-    "hv.Layout(temp_maps + [temp_curve]).cols(2).display('all')"
+    "hv.Layout(temp_maps + [temp_curve]).cols(2)"
    ]
   },
   {

--- a/doc/Gridded_Datasets_II.ipynb
+++ b/doc/Gridded_Datasets_II.ipynb
@@ -213,7 +213,7 @@
    "outputs": [],
    "source": [
     "%%opts BoxWhisker [xrotation=25 bgcolor='w']\n",
-    "hv.Layout([dataset.to.box(d, mdims=[]) for d in ['time', 'realization']])"
+    "hv.Layout([dataset.to.box(d, None, []) for d in ['time', 'realization']])"
    ]
   },
   {
@@ -235,7 +235,7 @@
     "%opts Distribution [bgcolor='w' show_grid=False xticks=[220, 300]]\n",
     "try:\n",
     "    import seaborn\n",
-    "    grid = dataset.to.distribution(mdims=['realization', 'time']).grid()\n",
+    "    grid = dataset.to.distribution(groupby=['realization', 'time']).grid()\n",
     "except:\n",
     "    grid = None\n",
     "grid"

--- a/doc/Homepage.ipynb
+++ b/doc/Homepage.ipynb
@@ -57,9 +57,9 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Image [colorbar=True] (cmap='viridis') Overlay [fig_size=200]\n",
+    "%%opts Image [colorbar=True fig_size=200] (cmap='viridis')\n",
     "ensemble = xr.open_dataset('./sample-data/ensemble.nc')\n",
-    "dataset = gv.Dataset(ensemble, crs=crs.PlateCarree())\n",
+    "dataset = gv.Dataset(ensemble, kdims=['longitude', 'latitude', 'time'], crs=crs.PlateCarree())\n",
     "dataset.to(gv.Image, ['longitude', 'latitude'], ['surface_temperature'], ['time']) * gf.coastline()"
    ]
   }

--- a/doc/Working_with_Bokeh.ipynb
+++ b/doc/Working_with_Bokeh.ipynb
@@ -127,7 +127,7 @@
    "outputs": [],
    "source": [
     "%%opts Overlay [width=600 height=300 xaxis=None yaxis=None] \n",
-    "%%opts Points (size=0.005 cmap='viridis') [tools=['hover'] color_index=2]\n",
+    "%%opts Points (size=0.005 cmap='viridis') [tools=['hover'] size_index=2 color_index=2]\n",
     "(gv.WMTS(tiles['Wikipedia']) *\\\n",
     "population.to(gv.Points, kdims=['Longitude', 'Latitude'],\n",
     "              vdims=['Population', 'City', 'Country'], crs=ccrs.PlateCarree()))"

--- a/doc/Working_with_Bokeh.ipynb
+++ b/doc/Working_with_Bokeh.ipynb
@@ -181,7 +181,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Shape (cmap='viridis') [xaxis=None yaxis=None tools=['hover'] width=400 height=500]\n",
+    "%%opts Shape (cmap='viridis') [xaxis=None yaxis=None tools=['hover'] width=400 height=500 colorbar=True]\n",
     "gv.Shape.from_records(shapes.records(), referendum, on='code', value='leaveVoteshare',\n",
     "                     index='name', crs=ccrs.PlateCarree(), group='EU Referendum')"
    ]

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -6,8 +6,8 @@ from cartopy.io.img_tiles import GoogleTiles as cGoogleTiles
 from cartopy.io.shapereader import Reader
 from holoviews.core import Element2D, Dimension, Dataset as HvDataset, NdOverlay
 from holoviews.core.util import basestring, pd
-from holoviews.element import (Text as HVText, Path as HVPath,
-                               Polygons as HVPolygons, GridImage)
+from holoviews.element import (Text as HvText, Path as HvPath,
+                               Polygons as HvPolygons, Image as HvImage)
 
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry import (MultiLineString, LineString,
@@ -85,7 +85,7 @@ class _Element(Element2D):
 
     def clone(self, data=None, shared_data=True, new_type=None,
               *args, **overrides):
-        if 'crs' not in overrides:
+        if 'crs' not in overrides and isinstance(new_type, _Element):
             overrides['crs'] = self.crs
         return super(_Element, self).clone(data, shared_data, new_type,
                                            *args, **overrides)
@@ -181,7 +181,7 @@ class Points(Dataset):
     group = param.String(default='Points')
 
 
-class LineContours(_Element, GridImage):
+class LineContours(_Element, HvImage):
     """
     Contours represents a 2D array of some quantity with
     some associated coordinates, which may be discretized
@@ -203,7 +203,7 @@ class FilledContours(LineContours):
     group = param.String(default='FilledContours')
 
 
-class Image(_Element, GridImage):
+class Image(_Element, HvImage):
     """
     Image represents a 2D array of some quantity with
     some associated coordinates.
@@ -214,14 +214,14 @@ class Image(_Element, GridImage):
     group = param.String(default='Image')
 
 
-class Text(HVText, _Element):
+class Text(HvText, _Element):
     """
     An annotation containing some text at an x, y coordinate
     along with a coordinate reference system.
     """
 
 
-class Path(_Element, HVPath):
+class Path(_Element, HvPath):
     """
     The Path Element contains a list of Paths stored as Nx2 numpy
     arrays along with a coordinate reference system.
@@ -237,7 +237,7 @@ class Path(_Element, HVPath):
         return MultiLineString(lines)
 
 
-class Polygons(_Element, HVPolygons):
+class Polygons(_Element, HvPolygons):
     """
     Polygons is a Path Element type that may contain any number of
     closed paths with an associated value and a coordinate reference

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -12,7 +12,7 @@ from holoviews import Store
 from holoviews.core import util
 from holoviews.core.options import SkipRendering, Options
 from holoviews.plotting.bokeh.annotation import TextPlot
-from holoviews.plotting.bokeh.element import ElementPlot, OverlayPlot
+from holoviews.plotting.bokeh.element import ElementPlot
 from holoviews.plotting.bokeh.chart import PointPlot
 from holoviews.plotting.bokeh.path import PolygonPlot, PathPlot
 from holoviews.plotting.bokeh.raster import RasterPlot

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -6,12 +6,13 @@ import numpy as np
 import shapely.geometry
 from cartopy.crs import GOOGLE_MERCATOR
 from bokeh.models import WMTSTileSource
+from bokeh.models.tools import BoxZoomTool
 
 from holoviews import Store
 from holoviews.core import util
 from holoviews.core.options import SkipRendering, Options
 from holoviews.plotting.bokeh.annotation import TextPlot
-from holoviews.plotting.bokeh.element import ElementPlot
+from holoviews.plotting.bokeh.element import ElementPlot, OverlayPlot
 from holoviews.plotting.bokeh.chart import PointPlot
 from holoviews.plotting.bokeh.path import PolygonPlot, PathPlot
 from holoviews.plotting.bokeh.raster import RasterPlot
@@ -31,6 +32,10 @@ class GeoPlot(ElementPlot):
     """
     Plotting baseclass for geographic plots with a cartopy projection.
     """
+
+    default_tools = param.List(default=['save', 'pan', 'wheel_zoom',
+                                        BoxZoomTool(match_aspect=True), 'reset'],
+        doc="A list of plugin tools to use on the plot.")
 
     show_grid = param.Boolean(default=False)
 

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -57,9 +57,10 @@ class GeoPlot(ElementPlot):
         return (np.NaN,)*4 if not extents else extents
 
 
+
 class TilePlot(GeoPlot):
 
-    styl_opts = ['alpha', 'render_parents']
+    style_opts = ['alpha', 'render_parents']
 
     def get_data(self, element, ranges=None, empty=False):
         tile_sources = [ts for ts in element.data
@@ -69,11 +70,18 @@ class TilePlot(GeoPlot):
                                 "Element, rendering skipped.")
         return {}, {'tile_source': tile_sources[0]}
 
+    def _update_glyphs(self, renderer, properties, mapping, glyph):
+        allowed_properties = glyph.properties()
+        merged = dict(properties, **mapping)
+        glyph.update(**{k: v for k, v in merged.items()
+                        if k in allowed_properties})
+
     def _init_glyph(self, plot, mapping, properties):
         """
         Returns a Bokeh glyph object.
         """
         renderer = plot.add_tile(mapping['tile_source'])
+        renderer.alpha = properties.get('alpha', 1)
         return renderer, renderer
 
 

--- a/tests/testconversions.py
+++ b/tests/testconversions.py
@@ -11,16 +11,16 @@ class TestConversions(ComparisonTestCase):
         self.cube = lat_lon_cube()
 
     def test_is_geographic_1d(self):
-        self.assertFalse(is_geographic(Dataset(self.cube), ['longitude']))
+        self.assertFalse(is_geographic(Dataset(self.cube, kdims=['longitude']), ['longitude']))
         
     def test_is_geographic_2d(self):
-        self.assertTrue(is_geographic(Dataset(self.cube), ['longitude', 'latitude']))
+        self.assertTrue(is_geographic(Dataset(self.cube, kdims=['longitude', 'latitude']), ['longitude', 'latitude']))
 
     def test_geographic_conversion(self):
-        self.assertEqual(Dataset(self.cube).to.image(), Image(self.cube))
+        self.assertEqual(Dataset(self.cube, kdims=['longitude', 'latitude']).to.image(), Image(self.cube, kdims=['longitude', 'latitude']))
         
     def test_nongeographic_conversion(self):
-        converted = Dataset(self.cube).to.curve(['longitude'])
+        converted = Dataset(self.cube, kdims=['longitude', 'latitude']).to.curve(['longitude'])
         self.assertTrue(isinstance(converted, HoloMap))
         self.assertEqual(converted.kdims, ['latitude'])
         self.assertTrue(isinstance(converted.last, Curve))


### PR DESCRIPTION
* Fixes tile source alpha control
* Ensures gv.Image inherits from hv.Image to avoid GridImage deprecation warnings
* Fixes for documentation notebooks
* Also sneakily put match_aspect=True for the box_zoom tool in here