### PR TITLE
GeoViews types default to PlateCarree CRS

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -57,7 +57,7 @@ class _Element(Element2D):
 
     _abstract = True
 
-    crs = param.ClassSelector(class_=ccrs.CRS, doc="""
+    crs = param.ClassSelector(default=ccrs.PlateCarree(), class_=ccrs.CRS, doc="""
         Cartopy coordinate-reference-system specifying the
         coordinate system of the data. Inferred automatically
         when _Element wraps cartopy Feature object.""")


### PR DESCRIPTION
All geoviews Elements default to PlateCarree CRS.