### PR TITLE
Allow passing bokeh tile source URL to WMTS

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -24,6 +24,11 @@ try:
 except:
     WMTSTileSource = None
 
+try:
+    from owslib.wmts import WebMapTileService
+except:
+    WebMapTileService = None
+
 geographic_types = (cGoogleTiles, cFeature)
 
 def is_geographic(element, kdims=None):
@@ -141,13 +146,13 @@ class WMTS(_GeoFeature):
             if WMTSTileSource and isinstance(d, WMTSTileSource):
                 if 'crs' not in params:
                     params['crs'] = ccrs.GOOGLE_MERCATOR
-            elif not isinstance(data, basestring):
+            elif WebMapTileService and isinstance(d, WebMapTileService):
                 if 'crs' not in params and not self.crs:
                     raise Exception('Must supply coordinate reference '
                                     'system with cartopy WMTS URL.')
-            else:
+            elif not isinstance(d, basestring):
                 raise TypeError('%s data has to be a tile service URL'
-                                % type(data).__name__)
+                                % type(d).__name__)
         super(WMTS, self).__init__(data, **params)
 
 

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -81,12 +81,22 @@ class TilePlot(GeoPlot):
     style_opts = ['alpha', 'render_parents']
 
     def get_data(self, element, ranges=None, empty=False):
-        tile_sources = [ts for ts in element.data
-                        if isinstance(ts, WMTSTileSource)]
-        if not tile_sources:
-            raise SkipRendering("No valid WMTSTileSource found in WMTS "
+        tile_source = None
+        for url in element.data:
+            if isinstance(url, util.basestring) and not url.endswith('cgi'):
+                try:
+                    tile_source = WMTSTileSource(url=url)
+                    break
+                except:
+                    pass
+            elif isinstance(url, WMTSTileSource):
+                tile_source = url
+                break
+
+        if tile_source is None:
+            raise SkipRendering("No valid tile source URL found in WMTS "
                                 "Element, rendering skipped.")
-        return {}, {'tile_source': tile_sources[0]}
+        return {}, {'tile_source': tile_source}
 
     def _update_glyph(self, renderer, properties, mapping, glyph):
         allowed_properties = glyph.properties()


### PR DESCRIPTION
Allows passing tile source URL directly to WMTS constructor avoiding having to import ``WMTSTileSource`` from bokeh. Also maintains backward compatibility so you can continue to pass in instances.