### PR TITLE
Add a faster image reprojection implementation

### DIFF
--- a/geoviews/operation.py
+++ b/geoviews/operation.py
@@ -160,8 +160,8 @@ class project_image(Operation):
         ys = element.dimension_values(1)
         if isinstance(element, RGB):
             rgb = element.rgb
-            array = np.dstack([np.flipud(element.dimension_values(d, flat=False))
-                               for d in element.vdims])
+            array = np.dstack([np.flipud(rgb.dimension_values(d, flat=False))
+                               for d in rgb.vdims])
         else:
             array = element.dimension_values(2, flat=False)
 

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -14,12 +14,11 @@ from holoviews.plotting.bokeh.annotation import TextPlot
 from holoviews.plotting.bokeh.element import ElementPlot, OverlayPlot as HvOverlayPlot
 from holoviews.plotting.bokeh.chart import PointPlot
 from holoviews.plotting.bokeh.path import PolygonPlot, PathPlot, ContourPlot
-from holoviews.plotting.bokeh.raster import RasterPlot
+from holoviews.plotting.bokeh.raster import RasterPlot, RGBPlot
 
 from ...element import (WMTS, Points, Polygons, Path, Contours, Shape, Image,
-                        Feature, is_geographic, Text, _Element)
-from ...operation import project_image, project_shape, project_points, project_path, project_image_fast
-from ...operation import 
+                        Feature, is_geographic, Text, RGB, _Element)
+from ...operation import project_image, project_shape, project_points, project_path
 from ...util import project_extents, geom_to_array
 
 DEFAULT_PROJ = GOOGLE_MERCATOR
@@ -150,21 +149,12 @@ class GeoPointPlot(GeoPlot, PointPlot):
 
 class GeoRasterPlot(GeoPlot, RasterPlot):
 
-    _project_operation = project_image
+    _project_operation = project_image.instance(fast=True)
 
-    def get_data(self, element, ranges=None, empty=False):
-        l, b, r, t = self.get_extents(element, ranges)
-        if self.geographic:
-            element = project_image_fast(element, projection=DEFAULT_PROJ)
-        img = element.dimension_values(2, flat=False)
-        mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
-        if empty:
-            data = dict(image=[], x=[], y=[], dw=[], dh=[])
-        else:
-            dh = t-b
-            data = dict(image=[img], x=[l],
-                        y=[b], dw=[r-l], dh=[dh])
-        return (data, mapping)
+
+class GeoRGBPlot(GeoPlot, RGBPlot):
+
+    _project_operation = project_image.instance(fast=True)
 
 
 class GeoPolygonPlot(GeoPlot, PolygonPlot):
@@ -261,6 +251,7 @@ Store.register({WMTS: TilePlot,
                 Path: GeoPathPlot,
                 Shape: GeoShapePlot,
                 Image: GeoRasterPlot,
+                RGB: GeoRGBPlot,
                 Feature: FeaturePlot,
                 Text: GeoTextPlot,
                 Overlay: OverlayPlot,

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -18,7 +18,8 @@ from holoviews.plotting.bokeh.raster import RasterPlot
 
 from ...element import (WMTS, Points, Polygons, Path, Contours, Shape, Image,
                         Feature, is_geographic, Text, _Element)
-from ...operation import project_image, project_shape, project_points, project_path
+from ...operation import project_image, project_shape, project_points, project_path, project_image_fast
+from ...operation import 
 from ...util import project_extents, geom_to_array
 
 DEFAULT_PROJ = GOOGLE_MERCATOR
@@ -150,6 +151,20 @@ class GeoPointPlot(GeoPlot, PointPlot):
 class GeoRasterPlot(GeoPlot, RasterPlot):
 
     _project_operation = project_image
+
+    def get_data(self, element, ranges=None, empty=False):
+        l, b, r, t = self.get_extents(element, ranges)
+        if self.geographic:
+            element = project_image_fast(element, projection=DEFAULT_PROJ)
+        img = element.dimension_values(2, flat=False)
+        mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
+        if empty:
+            data = dict(image=[], x=[], y=[], dw=[], dh=[])
+        else:
+            dh = t-b
+            data = dict(image=[img], x=[l],
+                        y=[b], dw=[r-l], dh=[dh])
+        return (data, mapping)
 
 
 class GeoPolygonPlot(GeoPlot, PolygonPlot):

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -20,6 +20,12 @@ def project_extents(extents, src_proj, dest_proj, tol=1e-6):
     if y1 < cy1: y1 = cy1
     if y2 > cy2:  y2 = cy2
 
+    # Offset with tolerances
+    x1 += tol
+    x2 -= tol
+    y1 += tol
+    y2 -= tol
+
     # Wrap longitudes
     cx1, cx2 = src_proj.x_limits
     if isinstance(src_proj, ccrs._CylindricalProjection):
@@ -28,12 +34,6 @@ def project_extents(extents, src_proj, dest_proj, tol=1e-6):
     else:
         if x1 < cx1: x1 = cx1
         if x2 > cx2: x2 = cx2
-
-    # Offset with tolerances
-    x1 += tol
-    x2 -= tol
-    y1 += tol
-    y2 -= tol
 
     domain_in_src_proj = Polygon([[x1, y1], [x2, y1],
                                   [x2, y2], [x1, y2],


### PR DESCRIPTION
A faster implementation for image reprojection which will be used by the bokeh interface. Here are some basic profiling results for the old (cartopy regrid) and new (resampling) implementation:

![bokeh_plot](https://user-images.githubusercontent.com/1550771/30435645-2a9ca2ca-9962-11e7-8b74-0a5ddfbd6963.png)
