### PR TITLE
Added GeoPandas data interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - source activate test-environment
   - pip install coveralls
   - pip install git+https://github.com/ioam/holoviews.git
-  - conda install -c conda-forge iris cartopy xarray
+  - conda install -c conda-forge iris cartopy xarray geopandas
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - source activate test-environment
   - pip install coveralls
   - pip install git+https://github.com/ioam/holoviews.git
-  - conda install -c conda-forge iris cartopy xarray geopandas
+  - conda install -c conda-forge iris cartopy xarray geopandas numpy=1.13.3
   - python setup.py install
 
 script:

--- a/doc/Geometries.ipynb
+++ b/doc/Geometries.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -16,8 +14,10 @@
     "import cartopy\n",
     "import cartopy.feature as cf\n",
     "from cartopy import crs as ccrs\n",
-    "hv.notebook_extension()\n",
-    "%output dpi=120"
+    "\n",
+    "hv.extension('matplotlib', 'bokeh')\n",
+    "\n",
+    "%output dpi=120 fig='svg'"
    ]
   },
   {
@@ -34,9 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "(gf.ocean + gf.land + gf.ocean * gf.land * gf.coastline * gf.borders).cols(3)"
@@ -52,9 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Feature.Lines [projection=ccrs.Robinson()] (facecolor='none' edgecolor='gray')\n",
@@ -77,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "land_geoms = list(gf.land.data.geometries())\n",
@@ -96,9 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Points (color=\"black\")\n",
@@ -117,9 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts NdOverlay [aspect=2]\n",
@@ -136,9 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "shapefile = './assets/boundaries/boundaries.shp'\n",
@@ -155,9 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "shapes = cartopy.io.shapereader.Reader(shapefile)\n",
@@ -174,9 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "referendum = pd.read_csv('./assets/referendum.csv')\n",
@@ -194,14 +178,74 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "%%output backend='bokeh'\n",
     "%%opts Shape (cmap='viridis')\n",
     "gv.Shape.from_records(shapes.records(), referendum, on='code', value='leaveVoteshare',\n",
     "                     index=['name', 'regionName'], crs=ccrs.PlateCarree())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GeoPandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "GeoViews ``Path``, ``Contours`` and ``Polygons`` Elements natively support projecting and plotting of\n",
+    "geopandas DataFrames using both ``matplotlib`` and ``bokeh`` plotting extensions. We will load the example dataset of the world which also includes some additional data about each country:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))\n",
+    "world.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can simply pass the GeoPandas DataFrame to a Polygons, Path or Contours element and it will plot the data for us. The ``Contours`` and ``Polygons`` will automatically color the data by the first specified value dimension defined by the ``vdims`` keyword (the geometries may be colored by any dimension using the ``color_index`` plot option):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Polygons [projection=ccrs.Robinson() fig_size=250]\n",
+    "gv.Polygons(world, vdims='pop_est')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Geometries can be displayed using both matplotlib and bokeh, here we will switch to bokeh allowing us to color by a categorical variable (``continent``) and activating the hover tool to reveal information about the plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%output backend='bokeh'\n",
+    "%%opts Polygons [width=600 height=500 tools=['hover']] (cmap='tab20')\n",
+    "gv.Polygons(world, vdims=['continent',  'name', 'pop_est']).redim.range(Latitude=(-60, 90))"
    ]
   },
   {
@@ -215,21 +259,21 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
   },
   "widgets": {
    "state": {},
@@ -237,5 +281,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/doc/Geometries.ipynb
+++ b/doc/Geometries.ipynb
@@ -198,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "GeoViews ``Path``, ``Contours`` and ``Polygons`` Elements natively support projecting and plotting of\n",
+    "GeoPandas extends the datatypes used by pandas to allow spatial operations on geometric types, which makes it a very convenient way of working with geometries with associated variables. GeoViews ``Path``, ``Contours`` and ``Polygons`` Elements natively support projecting and plotting of\n",
     "geopandas DataFrames using both ``matplotlib`` and ``bokeh`` plotting extensions. We will load the example dataset of the world which also includes some additional data about each country:"
    ]
   },

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -9,6 +9,7 @@ import param
 from .element import (_Element, Feature, Tiles,     # noqa (API import)
                       WMTS, LineContours, FilledContours, Text, Image,
                       Points, Path, Polygons, Shape, Dataset, RGB)
+from . import data                                  # noqa (API import)
 from . import operation                             # noqa (API import)
 from . import plotting                              # noqa (API import)
 from . import feature                               # noqa (API import)

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -8,7 +8,8 @@ import param
 
 from .element import (_Element, Feature, Tiles,     # noqa (API import)
                       WMTS, LineContours, FilledContours, Text, Image,
-                      Points, Path, Polygons, Shape, Dataset, RGB)
+                      Points, Path, Polygons, Shape, Dataset, RGB,
+                      Contours)
 from . import data                                  # noqa (API import)
 from . import operation                             # noqa (API import)
 from . import plotting                              # noqa (API import)

--- a/geoviews/data/__init__.py
+++ b/geoviews/data/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+import param
+
+try:
+    from . import geopandas
+except ImportError:
+    pass
+except Exception as e:
+    param.main.warning('GeoPandas interface failed to import with '
+                       'following error: %s' % e)
+

--- a/geoviews/data/__init__.py
+++ b/geoviews/data/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import param
 
 try:
-    from . import geopandas
+    from . import geopandas # noqa (API import)
 except ImportError:
     pass
 except Exception as e:

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import numpy as np
 from geopandas import GeoDataFrame
 
-from holoviews.core.data import Interface, MultiInterface, PandasInterface
+from holoviews.core.data import Interface, MultiInterface
 from holoviews.core.data.interface  import DataError
 from holoviews.core.util import max_range
 from holoviews.element import Path
@@ -40,7 +40,7 @@ class GeoPandasInterface(MultiInterface):
     @classmethod
     def validate(cls, dataset, vdims=True):
         dim_types = 'key' if vdims else 'all'
-        not_found = [d for d in dataset.dimensions(label='name')[2:]
+        not_found = [d for d in dataset.dimensions(dim_types, label='name')[2:]
                      if d not in dataset.data.columns]
         if not_found:
             raise DataError("Supplied data does not contain specified "

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
+
 import numpy as np
-import geopandas as gpd
+from geopandas import GeoDataFrame
 
 from holoviews.core.data import Interface, MultiInterface, PandasInterface
 from holoviews.core.data.interface  import DataError
@@ -11,7 +13,7 @@ from ..util import geom_to_array
 
 class GeoPandasInterface(MultiInterface):
 
-    types = (gpd.GeoDataFrame,)
+    types = (GeoDataFrame,)
 
     datatype = 'geodataframe'
 
@@ -19,7 +21,7 @@ class GeoPandasInterface(MultiInterface):
 
     @classmethod
     def init(cls, eltype, data, kdims, vdims):
-        if not isinstance(data, gpd.GeoDataFrame):
+        if not isinstance(data, GeoDataFrame):
             raise ValueError("GeoPandasInterface only support geopandas DataFrames.")
         elif 'geometry' not in data:
             raise DataError("GeoPandas dataframe must contain geometry column, "

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -1,0 +1,115 @@
+import numpy as np
+import geopandas as gpd
+
+from holoviews.core.data import Interface, MultiInterface
+from holoviews.core.util import max_range
+from holoviews.element import Path
+
+from ..util import geom_to_array
+
+
+class GeoPandasInterface(MultiInterface):
+
+    types = (gpd.GeoDataFrame,)
+
+    datatype = 'geodataframe'
+
+    @classmethod
+    def init(cls, eltype, data, kdims, vdims):
+        return data, {'kdims': eltype.kdims, 'vdims': []}, {}
+
+    @classmethod
+    def validate(cls, dataset):
+        pass
+
+    @classmethod
+    def dimension_type(cls, dataset, dim):
+        arr = geom_to_array(dataset.data.geometry.iloc[0])
+        ds = dataset.clone(arr, datatype=cls.subtypes, vdims=[])
+        return ds.interface.dimension_type(ds, dim)
+
+    @classmethod
+    def range(cls, dataset, dim):
+        dim = dataset.get_dimension_index(dim)
+        if dim in [0, 1]:
+            ranges = []
+            arr = geom_to_array(dataset.data.geometry.iloc[0])
+            ds = dataset.clone(arr, datatype=cls.subtypes, vdims=[])
+            for d in dataset.data.geometry:
+                ds.data = geom_to_array(d)
+                ranges.append(ds.interface.range(ds, dim))
+            return max_range(ranges)
+        else:
+            dim = dataset.get_dimension(dim)
+            vals = dataset.data[dim.name]
+            return vals.min(), vals.max()
+        
+    @classmethod
+    def aggregate(cls, columns, dimensions, function, **kwargs):
+        raise NotImplementedError
+
+    @classmethod
+    def groupby(cls, columns, dimensions, container_type, group_type, **kwargs):
+        raise NotImplementedError
+
+    @classmethod
+    def sample(cls, columns, samples=[]):
+        raise NotImplementedError
+
+    @classmethod
+    def shape(cls, dataset):
+        rows, cols = 0, 0
+        arr = geom_to_array(dataset.data.geometry.iloc[0])
+        ds = dataset.clone(arr, datatype=cls.subtypes, vdims=[])
+        for d in dataset.data.geometry:
+            ds.data = geom_to_array(d)
+            r, cols = ds.interface.shape(ds)
+            rows += r
+        return rows+len(dataset.data)-1, cols
+
+    @classmethod
+    def length(cls, dataset):
+        length = 0
+        arr = geom_to_array(dataset.data.geometry.iloc[0])
+        ds = dataset.clone(arr, datatype=cls.subtypes, vdims=[])
+        for d in dataset.data.geometry:
+            ds.data = geom_to_array(d)
+            length += ds.interface.length(ds)
+        return length+len(dataset.data)-1
+
+    @classmethod
+    def nonzero(cls, dataset):
+        return bool(cls.length(dataset))
+
+    @classmethod
+    def redim(cls, dataset, dimensions):
+        new_data = []
+        arr = geom_to_array(dataset.data.geometry.iloc[0])
+        ds = dataset.clone(arr, datatype=cls.subtypes, vdims=[])
+        for d in dataset.data.geometry:
+            ds.data = geom_to_array(d)
+            new_data.append(ds.interface.redim(ds, dimensions))
+        return new_data
+
+    @classmethod
+    def values(cls, dataset, dimension, expanded, flat):
+        values = []
+        arr = geom_to_array(dataset.data.geometry.iloc[0])
+        ds = dataset.clone(arr, datatype=cls.subtypes, vdims=[])
+        for d in dataset.data.geometry:
+            ds.data = geom_to_array(d)
+            values.append(ds.interface.values(ds, dimension))
+            values.append([np.NaN])
+        return np.concatenate(values[:-1]) if values else []
+
+    @classmethod
+    def split(cls, dataset, start, end):
+        objs = []
+        for d in dataset.data.geometry:
+            arr = geom_to_array(d)
+            objs.append(dataset.clone(arr, datatype=cls.subtypes, vdims=[]))
+        return objs
+
+
+Interface.register(GeoPandasInterface)
+Path.datatype += ['geodataframe']

--- a/geoviews/element/__init__.py
+++ b/geoviews/element/__init__.py
@@ -2,7 +2,8 @@ from holoviews.element import ElementConversion, Points as HvPoints
 
 from .geo import (_Element, Feature, Tiles, is_geographic,     # noqa (API import)
                   WMTS, Points, Image, Text, LineContours, RGB,
-                  FilledContours, Path, Polygons, Shape, Dataset)
+                  FilledContours, Path, Polygons, Shape, Dataset,
+                  Contours)
 
 
 class GeoConversion(ElementConversion):

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -8,7 +8,7 @@ from holoviews.core import Element2D, Dimension, Dataset as HvDataset, NdOverlay
 from holoviews.core.util import basestring, pd, max_extents, dimension_range
 from holoviews.element import (Text as HvText, Path as HvPath,
                                Polygons as HvPolygons, Image as HvImage,
-                               RGB as HvRGB)
+                               RGB as HvRGB, Contours as HvContours)
 
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry import (MultiLineString, LineString,
@@ -265,6 +265,20 @@ class Path(_Element, HvPath):
     """
     The Path Element contains a list of Paths stored as Nx2 numpy
     arrays along with a coordinate reference system.
+    """
+
+    def geom(self):
+        """
+        Returns Path as a shapely geometry.
+        """
+        return path_to_geom(self)
+
+
+class Contours(_Element, HvContours):
+    """
+    Contours is a Path Element type that may contain any number of
+    closed paths with an associated value and a coordinate reference
+    system.
     """
 
     def geom(self):

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -11,8 +11,6 @@ from holoviews.element import (Text as HvText, Path as HvPath,
                                RGB as HvRGB, Contours as HvContours)
 
 from shapely.geometry.base import BaseGeometry
-from shapely.geometry import (MultiLineString, LineString,
-                              MultiPolygon, Polygon)
 
 try:
     from iris.cube import Cube
@@ -29,7 +27,6 @@ try:
 except:
     WebMapTileService = None
 
-from ..data.geopandas import GeoPandasInterface
 from ..util import path_to_geom, polygon_to_geom
 
 geographic_types = (cGoogleTiles, cFeature, BaseGeometry)

--- a/geoviews/operation.py
+++ b/geoviews/operation.py
@@ -6,7 +6,7 @@ from shapely.geometry import Polygon, LineString
 
 from holoviews.operation import ElementOperation
 
-from .element import Image, Shape, Polygons, Path, Points
+from .element import Image, Shape, Polygons, Path, Points, Contours
 from .util import project_extents, geom_to_array
 
 
@@ -21,7 +21,7 @@ class project_path(ElementOperation):
                                      instantiate=False, doc="""
         Projection the shape type is projected to.""")
 
-    supported_types = [Polygons, Path]
+    supported_types = [Polygons, Path, Contours]
 
     def _process_element(self, element):
         if element.interface.datatype == 'geodataframe':

--- a/geoviews/operation.py
+++ b/geoviews/operation.py
@@ -2,16 +2,18 @@ import param
 import numpy as np
 from cartopy import crs as ccrs
 from cartopy.img_transform import warp_array
+from shapely.geometry import Polygon, LineString
 
 from holoviews.operation import ElementOperation
 
 from .element import Image, Shape, Polygons, Path, Points
-from .util import project_extents
+from .util import project_extents, geom_to_array
 
-class project_shape(ElementOperation):
+
+class project_path(ElementOperation):
     """
-    Projects Shape, Polygons and Path Elements from their source
-    coordinate reference system to the supplied projection.
+    Projects Polygons and Path Elements from their source coordinate
+    reference system to the supplied projection.
     """
 
     projection = param.ClassSelector(default=ccrs.GOOGLE_MERCATOR,
@@ -19,11 +21,49 @@ class project_shape(ElementOperation):
                                      instantiate=False, doc="""
         Projection the shape type is projected to.""")
 
-    supported_types = [Shape, Polygons, Path]
+    supported_types = [Polygons, Path]
 
     def _process_element(self, element):
-        geom = self.p.projection.project_geometry(element.geom(),
-                                                  element.crs)
+        if element.interface.datatype == 'geodataframe':
+            geoms = element.split(datatype='geom')
+            projected = [self.p.projection.project_geometry(geom, element.crs)
+                         for geom in geoms]
+            new_data = element.data.copy()
+            new_data['geometry'] = projected
+            return element.clone(new_data, crs=self.p.projection)
+
+        geom_type = Polygon if isinstance(element, Polygons) else LineString
+        xdim, ydim = element.kdims[:2]
+        projected = []
+        for geom in element.split(datatype='columns'):
+            xs, ys = geom[xdim.name], geom[ydim.name]
+            path = geom_type(np.column_stack([xs, ys]))
+            proj = self.p.projection.project_geometry(path, element.crs)
+            proj_arr = geom_to_array(proj)
+            geom[xdim.name] = proj_arr[:, 0]
+            geom[ydim.name] = proj_arr[:, 1]
+            projected.append(geom)
+        return element.clone(projected, crs=self.p.projection)
+
+    def _process(self, element, key=None):
+        return element.map(self._process_element, self.supported_types)
+
+
+class project_shape(ElementOperation):
+    """
+    Projects Shape Element from the source coordinate reference system
+    to the supplied projection.
+    """
+
+    projection = param.ClassSelector(default=ccrs.GOOGLE_MERCATOR,
+                                     class_=ccrs.Projection,
+                                     instantiate=False, doc="""
+        Projection the shape type is projected to.""")
+
+    supported_types = [Shape]
+
+    def _process_element(self, element):
+        geom = self.p.projection.project_geometry(element.geom(), element.crs)
         return element.clone(geom, crs=self.p.projection)
 
     def _process(self, element, key=None):
@@ -98,6 +138,7 @@ class project(ElementOperation):
         Projection the image type is projected to.""")
 
     def _process(self, element, key=None):
+        element = element.map(project_path, project_path.supported_types)
         element = element.map(project_image, project_image.supported_types)
         element = element.map(project_shape, project_shape.supported_types)
         return element.map(project_points, project_points.supported_types)

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -1,12 +1,11 @@
 import copy
-import itertools
 
 import param
 import numpy as np
 import shapely.geometry
 from cartopy.crs import GOOGLE_MERCATOR
 from bokeh.models import WMTSTileSource, MercatorTickFormatter, MercatorTicker
-from bokeh.models.tools import BoxZoomTool, HoverTool
+from bokeh.models.tools import BoxZoomTool
 
 from holoviews import Store, Overlay, NdOverlay
 from holoviews.core import util

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -14,10 +14,10 @@ from holoviews.core.options import SkipRendering, Options
 from holoviews.plotting.bokeh.annotation import TextPlot
 from holoviews.plotting.bokeh.element import ElementPlot, OverlayPlot as HvOverlayPlot
 from holoviews.plotting.bokeh.chart import PointPlot
-from holoviews.plotting.bokeh.path import PolygonPlot, PathPlot
+from holoviews.plotting.bokeh.path import PolygonPlot, PathPlot, ContourPlot
 from holoviews.plotting.bokeh.raster import RasterPlot
 
-from ...element import (WMTS, Points, Polygons, Path, Shape, Image,
+from ...element import (WMTS, Points, Polygons, Path, Contours, Shape, Image,
                         Feature, is_geographic, Text, _Element)
 from ...operation import project_image, project_shape, project_points, project_path
 from ...util import project_extents, geom_to_array
@@ -158,6 +158,11 @@ class GeoPolygonPlot(GeoPlot, PolygonPlot):
     _project_operation = project_path
 
 
+class GeoContourPlot(GeoPlot, ContourPlot):
+
+    _project_operation = project_path
+
+
 class GeoPathPlot(GeoPlot, PathPlot):
 
     _project_operation = project_path
@@ -174,9 +179,9 @@ class GeoShapePlot(GeoPolygonPlot):
             data = dict(xs=[xs], ys=[ys])
 
         mapping = dict(self._mapping)
+        dim = element.vdims[0].name if element.vdims else None
         if element.level is not None:
             cmap = style.get('palette', style.get('cmap', None))
-            dim = element.vdims[0].name if element.vdims else None
             if cmap and dim:
                 cdim = element.vdims[0]
                 dim_name = util.dimension_sanitizer(cdim.name)
@@ -238,6 +243,7 @@ class GeoTextPlot(GeoPlot, TextPlot):
 Store.register({WMTS: TilePlot,
                 Points: GeoPointPlot,
                 Polygons: GeoPolygonPlot,
+                Contours: GeoContourPlot,
                 Path: GeoPathPlot,
                 Shape: GeoShapePlot,
                 Image: GeoRasterPlot,

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -19,7 +19,7 @@ from holoviews.plotting.bokeh.raster import RasterPlot
 
 from ...element import (WMTS, Points, Polygons, Path, Shape, Image,
                         Feature, is_geographic, Text, _Element)
-from ...operation import project_image
+from ...operation import project_image, project_shape, project_points, project_path
 from ...util import project_extents, geom_to_array
 
 DEFAULT_PROJ = GOOGLE_MERCATOR
@@ -46,6 +46,9 @@ class GeoPlot(ElementPlot):
 
     show_grid = param.Boolean(default=False, doc="""
         Whether to show gridlines on the plot.""")
+
+    # Project operation to apply to the element
+    _project_operation = None
 
     def __init__(self, element, **params):
         super(GeoPlot, self).__init__(element, **params)
@@ -81,6 +84,11 @@ class GeoPlot(ElementPlot):
                 extents = None
         return (np.NaN,)*4 if not extents else extents
 
+
+    def get_data(self, element, ranges, style):
+        if self._project_operation and self.geographic and element.crs != DEFAULT_PROJ:
+            element = self._project_operation(element)
+        return super(GeoPlot, self).get_data(element, ranges, style)
 
 
 class OverlayPlot(GeoPlot, HvOverlayPlot):
@@ -137,72 +145,22 @@ class TilePlot(GeoPlot):
 
 class GeoPointPlot(GeoPlot, PointPlot):
 
-    def get_data(self, element, ranges, style):
-        data, mapping, style = super(GeoPointPlot, self).get_data(element, ranges, style)
-        if self.static_source: return data, mapping, style
-        xdim, ydim = element.dimensions('key', label=True)
-        if len(data[xdim]) and element.crs not in [DEFAULT_PROJ, None]:
-            points = DEFAULT_PROJ.transform_points(element.crs, data[xdim],
-                                                   data[ydim])
-            data[xdim] = points[:, 0]
-            data[ydim] = points[:, 1]
-        return data, mapping, style
+    _project_operation = project_points
 
 
 class GeoRasterPlot(GeoPlot, RasterPlot):
 
-    def get_data(self, element, ranges, style):
-        if self.geographic:
-            element = project_image(element, projection=DEFAULT_PROJ)
-        return RasterPlot.get_data(self, element, ranges, style)
+    _project_operation = project_image
 
 
+class GeoPolygonPlot(GeoPlot, PolygonPlot):
 
-class GeometryPlot(GeoPlot):
-    """
-    Geometry projects a geometry to the destination coordinate
-    reference system before creating the glyph.
-    """
-
-    def get_data(self, element, ranges, style):
-        if not self.geographic:
-            return super(GeometryPlot, self).get_data(element, ranges, style)
-        
-        if self.static_source:
-            data = {}
-        else:
-            geoms = element.geom()
-            if element.crs:
-                geoms = DEFAULT_PROJ.project_geometry(geoms, element.crs)
-            xs, ys = geom_to_array(geoms)
-            data = dict(xs=ys, ys=xs) if self.invert_axes else dict(xs=xs, ys=ys)
-
-        mapping = dict(self._mapping)
-        if element.vdims and getattr(element, 'level', None) is not None:
-            cdim = element.vdims[0]
-            dim_name = util.dimension_sanitizer(cdim.name)
-            data[dim_name] = [element.level for _ in range(len(xs))]
-            cmapper = self._get_colormapper(cdim, element, ranges, style)
-            color_prop = 'fill_color' if isinstance(element, Polygons) else 'line_color'
-            mapping[color_prop] = {'field': dim_name, 'transform': cmapper}
-
-        if any(isinstance(t, HoverTool) for t in self.state.tools):
-            dim_name = util.dimension_sanitizer(element.vdims[0].name)
-            for k, v in self.overlay_dims.items():
-                dim = util.dimension_sanitizer(k.name)
-                data[dim] = [v for _ in range(len(xs))]
-            data[dim_name] = [element.level for _ in range(len(xs))]
-
-        self._get_hover_data(data, element)
-        return data, mapping, style
+    _project_operation = project_path
 
 
-class GeoPolygonPlot(GeometryPlot, PolygonPlot):
-    pass
+class GeoPathPlot(GeoPlot, PathPlot):
 
-
-class GeoPathPlot(GeometryPlot, PathPlot):
-    pass
+    _project_operation = project_path
 
 
 class GeoShapePlot(GeoPolygonPlot):
@@ -211,15 +169,9 @@ class GeoShapePlot(GeoPolygonPlot):
         if self.static_source:
             data = {}
         else:
-            geoms = element.geom()
-            empty = False
-            if self.geographic and element.crs != DEFAULT_PROJ:
-                try:
-                    geoms = DEFAULT_PROJ.project_geometry(geoms, element.crs)
-                except:
-                    empty = True
-            xs, ys = ([], []) if empty else geom_to_array(geoms)
-            data = dict(xs=xs, ys=ys)
+            xs, ys = geom_to_array(project_shape(element).geom()).T
+            if self.invert_axes: xs, ys = ys, xs
+            data = dict(xs=[xs], ys=[ys])
 
         mapping = dict(self._mapping)
         if element.level is not None:
@@ -229,14 +181,14 @@ class GeoShapePlot(GeoPolygonPlot):
                 cdim = element.vdims[0]
                 dim_name = util.dimension_sanitizer(cdim.name)
                 cmapper = self._get_colormapper(cdim, element, ranges, style)
-                data[dim_name] = [] if empty else [element.level for _ in range(len(xs))]
+                data[dim_name] = [element.level]
                 mapping['fill_color'] = {'field': dim_name,
                                          'transform': cmapper}
 
         if 'hover' in self.tools+self.default_tools:
             if dim:
                 dim_name = util.dimension_sanitizer(dim)
-                data[dim_name] = [element.level for _ in range(len(xs))]
+                data[dim_name] = [element.level]
             for k, v in self.overlay_dims.items():
                 dim = util.dimension_sanitizer(k.name)
                 data[dim] = [v for _ in range(len(xs))]
@@ -262,11 +214,8 @@ class FeaturePlot(GeoPolygonPlot):
             self._plot_methods = dict(single='patches', batched='patches')
         geoms = [DEFAULT_PROJ.project_geometry(geom, element.crs)
                  for geom in geoms]
-        arrays = [geom_to_array(geom) for geom in geoms]
-        xs = [arr[0] for arr in arrays]
-        ys = [arr[1] for arr in arrays]
-        data = dict(xs=list(itertools.chain(*xs)),
-                    ys=list(itertools.chain(*ys)))
+        xs, ys = zip(*(geom_to_array(geom).T for geom in geoms))
+        data = dict(xs=list(xs), ys=list(ys))
         return data, mapping, style
 
 
@@ -274,7 +223,7 @@ class GeoTextPlot(GeoPlot, TextPlot):
 
     def get_data(self, element, ranges, style):
         mapping = dict(x='x', y='y', text='text')
-        if self.geographic:
+        if not self.geographic:
             return super(GeoTextPlot, self).get_data(element, ranges, style)
         if element.crs:
             x, y = DEFAULT_PROJ.transform_point(element.x, element.y,

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -18,13 +18,14 @@ from holoviews.plotting.mpl import (ElementPlot, ColorbarPlot, PointPlot,
                                     AnnotationPlot, TextPlot,
                                     LayoutPlot as HvLayoutPlot,
                                     OverlayPlot as HvOverlayPlot,
-                                    PathPlot, PolygonPlot, ImagePlot)
+                                    PathPlot, PolygonPlot, ImagePlot,
+                                    ContourPlot)
 from holoviews.plotting.mpl.util import get_raster_array
 
 
 from ...element import (Image, Points, Feature, WMTS, Tiles, Text,
                         LineContours, FilledContours, is_geographic,
-                        Path, Polygons, Shape, RGB)
+                        Path, Polygons, Shape, RGB, Contours)
 from ...util import path_to_geom, polygon_to_geom, project_extents, geo_mesh
 
 from ...operation import project_points, project_path
@@ -303,7 +304,17 @@ class GeometryPlot(GeoPlot):
 
 class GeoPathPlot(GeoPlot, PathPlot):
     """
-    Draws a scatter plot from the data in a Points Element.
+    Draws a Path plot from a Path Element.
+    """
+
+    apply_ranges = param.Boolean(default=True)
+
+    _project_operation = project_path
+
+
+class GeoContourPlot(GeoPlot, ContourPlot):
+    """
+    Draws a contour plot from a Contours Element.
     """
 
     apply_ranges = param.Boolean(default=True)
@@ -476,6 +487,7 @@ Store.register({LineContours: LineContourPlot,
                 Overlay: OverlayPlot,
                 Polygons: GeoPolygonPlot,
                 Path: GeoPathPlot,
+                Contours: GeoContourPlot,
                 RGB: GeoRGBPlot,
                 Shape: GeoShapePlot}, 'matplotlib')
 

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -26,7 +26,7 @@ from holoviews.plotting.mpl.util import get_raster_array
 from ...element import (Image, Points, Feature, WMTS, Tiles, Text,
                         LineContours, FilledContours, is_geographic,
                         Path, Polygons, Shape, RGB, Contours)
-from ...util import path_to_geom, polygon_to_geom, project_extents, geo_mesh
+from ...util import project_extents, geo_mesh
 
 from ...operation import project_points, project_path
 
@@ -192,6 +192,7 @@ class LineContourPlot(GeoPlot, ColorbarPlot):
 
     def get_data(self, element, ranges, style):
         args = geo_mesh(element)
+        style.pop('label', None)
         if isinstance(self.levels, int):
             args += (self.levels,)
         else:

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -1,10 +1,7 @@
 import numpy as np
 from cartopy import crs as ccrs
-from shapely.geometry import (MultiLineString, LineString,
-                              MultiPolygon, Polygon, asLineString,
-                              asPolygon)
+from shapely.geometry import (MultiLineString, LineString, MultiPolygon, Polygon)
 
-#from .element import RGB
 
 
 def wrap_lons(lons, base, period):
@@ -126,10 +123,11 @@ def geo_mesh(element):
     on a cylindrical coordinate system and wraps globally that data
     actually wraps around.
     """
-    if isinstance(element, RGB):
+    if len(element.vdims) > 1:
         xs, ys = (element.dimension_values(i, False, False)
                   for i in range(2))
-        zs = np.dstack([element.dimension_values(i, False, False) for i in range(2, 2+len(element.vdims))])
+        zs = np.dstack([element.dimension_values(i, False, False)
+                        for i in range(2, 2+len(element.vdims))])
     else:
         xs, ys, zs = (element.dimension_values(i, False, False)
                       for i in range(3))

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -67,18 +67,26 @@ def polygon_to_geom(polygon):
     return MultiPolygon(polys)
 
 
-def geom_to_array(geoms):
-    xs, ys = [], []
-    for geom in geoms:
-        if hasattr(geom, 'exterior'):
-            xs.append(np.array(geom.exterior.coords.xy[0]))
-            ys.append(np.array(geom.exterior.coords.xy[1]))
-        else:
-            geom_data = geom.array_interface()
-            arr = np.array(geom_data['data']).reshape(geom_data['shape'])
+def geom_to_arr(geom):
+    arr = geom.array_interface_base['data']
+    return np.array(arr).reshape(int(len(arr)/2), 2)
+
+
+def geom_to_array(geom):
+    if hasattr(geom, 'exterior'):
+        xs = np.array(geom.exterior.coords.xy[0])
+        ys = np.array(geom.exterior.coords.xy[1])
+    else:
+        xs, ys = [], []
+        for g in geom:
+            arr = geom_to_arr(g)
             xs.append(arr[:, 0])
             ys.append(arr[:, 1])
-    return xs, ys
+            xs.append([np.NaN])
+            ys.append([np.NaN])
+        xs = np.concatenate(xs)
+        ys = np.concatenate(ys)
+    return np.column_stack([xs, ys])
 
 
 def geo_mesh(element):


### PR DESCRIPTION
Adds a GeoPandas interface allowing Path and Polygon types to wrap around geopandas dataframes directly. Here is a basic example:

https://anaconda.org/philippjfr/geopandas/notebook

Requires holoviews master and will likely be released at the same time as HoloViews 1.9.