### PR TITLE
Fixed WMTS update with url

### DIFF
--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -100,6 +100,7 @@ class TilePlot(GeoPlot):
 
     def _update_glyph(self, renderer, properties, mapping, glyph):
         allowed_properties = glyph.properties()
+        mapping['url'] = mapping.pop('tile_source').url
         merged = dict(properties, **mapping)
         glyph.update(**{k: v for k, v in merged.items()
                         if k in allowed_properties})


### PR DESCRIPTION
In previous PRs we allowed creating a WMTS element with just a URL, however the plotting code then ended up trying to replace the original tile source object. This fixes this issue.