### PR TITLE
Add geoviews.data package to installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup_args.update(dict(
     license='BSD',
     url='https://github.com/ioam/geoviews',
     packages = ["geoviews",
+                "geoviews.data",
                 "geoviews.element",
                 "geoviews.plotting",
                 "geoviews.plotting.bokeh",


### PR DESCRIPTION
This is to fix an `ImportError` that gets raised by [this line](https://github.com/ioam/geoviews/blob/master/geoviews/__init__.py#L13) in geoviews for the "geoviews.data" package.