### PR TITLE
Add projection aware Graph and TriMesh elements

### DIFF
--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -9,7 +9,7 @@ import param
 from .element import (_Element, Feature, Tiles,     # noqa (API import)
                       WMTS, LineContours, FilledContours, Text, Image,
                       Points, Path, Polygons, Shape, Dataset, RGB,
-                      Contours)
+                      Contours, Graph, TriMesh, Nodes, EdgePaths )
 from . import data                                  # noqa (API import)
 from . import operation                             # noqa (API import)
 from . import plotting                              # noqa (API import)

--- a/geoviews/element/__init__.py
+++ b/geoviews/element/__init__.py
@@ -3,7 +3,7 @@ from holoviews.element import ElementConversion, Points as HvPoints
 from .geo import (_Element, Feature, Tiles, is_geographic,     # noqa (API import)
                   WMTS, Points, Image, Text, LineContours, RGB,
                   FilledContours, Path, Polygons, Shape, Dataset,
-                  Contours)
+                  Contours, TriMesh, Graph, Nodes, EdgePaths)
 
 
 class GeoConversion(ElementConversion):

--- a/geoviews/operation.py
+++ b/geoviews/operation.py
@@ -97,7 +97,7 @@ class project_graph(_project_operation):
         nodes = project_points(element.nodes, projection=self.projection)
         data = (element.data, nodes)
         if element._edgepaths:
-            data = data + (project_path(element.edgepaths),)
+            data = data + (project_path(element.edgepaths, projection=self.projection),)
         return element.clone(data)
 
 

--- a/geoviews/operation.py
+++ b/geoviews/operation.py
@@ -98,7 +98,7 @@ class project_graph(_project_operation):
         data = (element.data, nodes)
         if element._edgepaths:
             data = data + (project_path(element.edgepaths, projection=self.projection),)
-        return element.clone(data)
+        return element.clone(data, crs=self.projection)
 
 
 class project_image(_project_operation):

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -9,12 +9,15 @@ from holoviews.core import util
 from holoviews.core.options import SkipRendering, Options
 from holoviews.plotting.bokeh.annotation import TextPlot
 from holoviews.plotting.bokeh.chart import PointPlot
+from holoviews.plotting.bokeh.graphs import TriMeshPlot, GraphPlot
 from holoviews.plotting.bokeh.path import PolygonPlot, PathPlot, ContourPlot
 from holoviews.plotting.bokeh.raster import RasterPlot, RGBPlot
 
 from ...element import (WMTS, Points, Polygons, Path, Contours, Shape,
-                        Image, Feature, Text, RGB)
-from ...operation import project_image, project_shape, project_points, project_path
+                        Image, Feature, Text, RGB, Nodes, EdgePaths,
+                        Graph, TriMesh)
+from ...operation import (project_image, project_shape, project_points,
+                          project_path, project_graph)
 from ...util import geom_to_array
 from .plot import GeoPlot, OverlayPlot, DEFAULT_PROJ
 from . import callbacks # noqa
@@ -96,6 +99,16 @@ class GeoContourPlot(GeoPlot, ContourPlot):
 class GeoPathPlot(GeoPlot, PathPlot):
 
     _project_operation = project_path
+
+
+class GeoGraphPlot(GeoPlot, GraphPlot):
+
+    _project_operation = project_graph
+
+
+class GeoTriMeshPlot(GeoPlot, TriMeshPlot):
+
+    _project_operation = project_graph
 
 
 class GeoShapePlot(GeoPolygonPlot):
@@ -183,7 +196,11 @@ Store.register({WMTS: TilePlot,
                 Feature: FeaturePlot,
                 Text: GeoTextPlot,
                 Overlay: OverlayPlot,
-                NdOverlay: OverlayPlot}, 'bokeh')
+                NdOverlay: OverlayPlot,
+                Graph: GeoGraphPlot,
+                TriMesh: GeoTriMeshPlot,
+                Nodes: GeoPointPlot,
+                EdgePaths: GeoPathPlot}, 'bokeh')
 
 options = Store.options(backend='bokeh')
 

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -19,16 +19,17 @@ from holoviews.plotting.mpl import (ElementPlot, ColorbarPlot, PointPlot,
                                     LayoutPlot as HvLayoutPlot,
                                     OverlayPlot as HvOverlayPlot,
                                     PathPlot, PolygonPlot, ImagePlot,
-                                    ContourPlot)
+                                    ContourPlot, GraphPlot, TriMeshPlot)
 from holoviews.plotting.mpl.util import get_raster_array
 
 
 from ...element import (Image, Points, Feature, WMTS, Tiles, Text,
                         LineContours, FilledContours, is_geographic,
-                        Path, Polygons, Shape, RGB, Contours)
+                        Path, Polygons, Shape, RGB, Contours, Nodes,
+                        EdgePaths, Graph, TriMesh)
 from ...util import project_extents, geo_mesh
 
-from ...operation import project_points, project_path
+from ...operation import project_points, project_path, project_graph
 
 
 def _get_projection(el):
@@ -353,7 +354,21 @@ class GeoShapePlot(GeometryPlot, PolygonPlot):
             SkipRendering('Shape can only be plotted on geographic plot, '
                           'supply a coordinate reference system.')
 
-        
+
+class GeoGraphPlot(GeoPlot, GraphPlot):
+
+    apply_ranges = param.Boolean(default=True)
+
+    _project_operation = project_graph
+
+
+class GeoTriMeshPlot(GeoPlot, TriMeshPlot):
+
+    apply_ranges = param.Boolean(default=True)
+
+    _project_operation = project_graph
+
+
 ########################################
 #  Geographic features and annotations #
 ########################################
@@ -490,7 +505,11 @@ Store.register({LineContours: LineContourPlot,
                 Path: GeoPathPlot,
                 Contours: GeoContourPlot,
                 RGB: GeoRGBPlot,
-                Shape: GeoShapePlot}, 'matplotlib')
+                Shape: GeoShapePlot,
+                Graph: GeoGraphPlot,
+                TriMesh: GeoTriMeshPlot,
+                Nodes: GeoPointPlot,
+                EdgePaths: GeoPathPlot}, 'matplotlib')
 
 
 # Define plot and style options


### PR DESCRIPTION
This adds support for projection aware ``Graph`` elements to GeoViews including the basic ``Graph`` element and the ``TriMesh`` element. It relies on https://github.com/ioam/holoviews/pull/2240 to work correctly.