### PR TITLE
Added pre- and post-processors to HoloViews operations

### DIFF
--- a/geoviews/operation.py
+++ b/geoviews/operation.py
@@ -3,13 +3,65 @@ import numpy as np
 
 from cartopy import crs as ccrs
 from cartopy.img_transform import warp_array, _determine_bounds
+from holoviews.core import Element
 from holoviews.core.util import cartesian_product, get_param_values
 from holoviews.operation import Operation
 from shapely.geometry import Polygon, LineString
 
+from . import element as gv_element
 from .element import (Image, Shape, Polygons, Path, Points, Contours,
-                      RGB, Graph, Nodes, EdgePaths, QuadMesh)
+                      RGB, Graph, Nodes, EdgePaths, QuadMesh, _Element)
 from .util import project_extents, geom_to_array
+
+geo_ops = []
+try:
+    from holoviews.operation.datashader import (
+        ResamplingOperation, shade, stack, dynspread)
+    geo_ops += [ResamplingOperation, shade, stack, dynspread]
+except:
+    pass
+
+from holoviews.operation.element import contours
+from holoviews.operation.stats import bivariate_kde
+
+geo_ops += [contours, bivariate_kde]
+
+def convert_to_geotype(element, crs=None):
+    """
+    Converts a HoloViews element type to the equivalent GeoViews
+    element if given a coordinate reference system.
+    """
+    geotype = getattr(gv_element, type(element).__name__, None)
+    if crs is None or geotype is None or isinstance(element, _Element):
+        return element
+    return geotype(element, crs=crs)
+
+
+def find_crs(element):
+    """
+    Traverses the supplied object looking for coordinate reference
+    systems (crs). If multiple clashing reference systems are found
+    it will throw an error.
+    """
+    crss = element.traverse(lambda x: x.crs, [_Element])
+    crss = [crs for crs in crss if crs is not None]
+    if any(crss[0] != crs for crs in crss[1:] if crs is not None):
+        raise ValueError('Cannot datashade Elements in different '
+                         'coordinate reference systems.')
+    return {'crs': crss[0] if crss else None}
+
+
+def add_crs(element, **kwargs):
+    """
+    Converts any elements in the input to their equivalent geotypes
+    if given a coordinate reference system.
+    """
+    return element.map(lambda x: convert_to_geotype(x, kwargs.get('crs')), Element)
+
+
+for op in geo_ops:
+    op._preprocess_hooks = op._preprocess_hooks + [find_crs]
+    op._postprocess_hooks = op._postprocess_hooks + [add_crs]
 
 
 class _project_operation(Operation):


### PR DESCRIPTION
This PR adds pre- and post-processors to HoloViews operations such as the datashader operations, which ensure that they do not drop any GeoViews coordinate reference system information. Addresses https://github.com/ioam/geoviews/issues/45, which makes working with datashader and GeoViews much easier.