### PR TITLE
Unified WMTS element support across backends

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -2,7 +2,7 @@ import param
 import numpy as np
 from cartopy import crs as ccrs
 from cartopy.feature import Feature as cFeature
-from cartopy.io.img_tiles import GoogleTiles as cGoogleTiles
+from cartopy.io.img_tiles import GoogleTiles
 from cartopy.io.shapereader import Reader
 from holoviews.core import Element2D, Dimension, Dataset as HvDataset, NdOverlay
 from holoviews.core.util import (basestring, pd, max_extents,
@@ -32,7 +32,7 @@ except:
 
 from ..util import path_to_geom, polygon_to_geom
 
-geographic_types = (cGoogleTiles, cFeature, BaseGeometry)
+geographic_types = (GoogleTiles, cFeature, BaseGeometry)
 
 def is_geographic(element, kdims=None):
     """
@@ -81,7 +81,7 @@ class _Element(Element2D):
             coord_sys = crs_data.coord_system()
             if hasattr(coord_sys, 'as_cartopy_projection'):
                 crs = coord_sys.as_cartopy_projection()
-        elif isinstance(crs_data, (cFeature, cGoogleTiles)):
+        elif isinstance(crs_data, (cFeature, GoogleTiles)):
             crs = crs_data.crs
 
         supplied_crs = kwargs.get('crs', None)
@@ -141,8 +141,10 @@ class Feature(_GeoFeature):
 
 class WMTS(_GeoFeature):
     """
-    The WMTS Element represents a Web Map Tile Service
-    specified as a tuple of the API URL and
+    The WMTS Element represents a Web Map Tile Service specified as a
+    URL containing {x}, {y}, and {z} templating variables, e.g.:
+
+    https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png
     """
 
     group = param.String(default='WMTS')
@@ -150,41 +152,24 @@ class WMTS(_GeoFeature):
     layer = param.String(doc="The layer on the tile service")
 
     def __init__(self, data, kdims=None, vdims=None, **params):
-        if isinstance(data, tuple):
-            data = data
-        else:
-            data = (data,)
-
-        for d in data:
-            if WMTSTileSource and isinstance(d, WMTSTileSource):
-                if not 'crs' in params:
-                    params['crs'] = ccrs.GOOGLE_MERCATOR
-            elif WebMapTileService and isinstance(d, WebMapTileService):
-                if 'crs' not in params and not self.crs:
-                    raise Exception('Must supply coordinate reference '
-                                    'system with cartopy WMTS URL.')
-            elif not isinstance(d, basestring):
-                raise TypeError('%s data has to be a tile service URL'
-                                % type(d).__name__)
-            elif not 'crs' in params:
-                params['crs'] = ccrs.GOOGLE_MERCATOR
+        if ((WMTSTileSource and isinstance(data, WMTSTileSource)) or
+            (GoogleTiles and isinstance(data, GoogleTiles))):
+            data = data.url
+        elif WebMapTileService and isinstance(data, WebMapTileService):
+            pass
+        elif not isinstance(data, basestring):
+            raise TypeError('%s data should be a tile service URL not a %s type.'
+                            % (type(self).__name__, type(data).__name__) )
         super(WMTS, self).__init__(data, kdims=kdims, vdims=vdims, **params)
 
 
-class Tiles(_GeoFeature):
+class Tiles(WMTS):
     """
     Tiles represents an image tile source to dynamically
     load data from depending on the zoom level.
     """
 
     group = param.String(default='Tiles')
-
-    def __init__(self, data, kdims=None, vdims=None, **params):
-        if not isinstance(data, cGoogleTiles):
-            raise TypeError('%s data has to be a cartopy GoogleTiles type'
-                            % type(data).__name__)
-        super(Tiles, self).__init__(data, kdims=kdims, vdims=vdims, **params)
-
 
 
 class Dataset(_Element, HvDataset):

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -37,22 +37,10 @@ class TilePlot(GeoPlot):
         return extents
 
     def get_data(self, element, ranges, style):
-        tile_source = None
-        for url in element.data:
-            if isinstance(url, util.basestring) and not url.endswith('cgi'):
-                try:
-                    tile_source = WMTSTileSource(url=url)
-                    break
-                except:
-                    pass
-            elif isinstance(url, WMTSTileSource):
-                tile_source = url
-                break
-
-        if tile_source is None:
-            raise SkipRendering("No valid tile source URL found in WMTS "
-                                "Element, rendering skipped.")
-        return {}, {'tile_source': tile_source}, style
+        if not isinstance(element.data, util.basestring):
+            SkipRendering("WMTS element data must be a URL string, "
+                          "bokeh cannot render %r" % element.data)
+        return {}, {'tile_source': WMTSTileSource(url=element.data)}, style
 
     def _update_glyph(self, renderer, properties, mapping, glyph):
         allowed_properties = glyph.properties()


### PR DESCRIPTION
The WMTS element now supports the tile source URL format that is also supported by bokeh, finally unifying the two. This PR also deprecates ``Tiles`` since it does exactly what WMTS does. I'd also be happy to keep Tiles as a simple alias for WMTS though, @jbednar any thoughts?

Here's the same plot in two backends:

```
tiles = gv.WMTS('https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png') 

# Project data to Web Mercator
nybb = gpd.read_file(gpd.datasets.get_path('nybb'))
poly_data = nybb.to_crs(ccrs.GOOGLE_MERCATOR.proj4_init)
polys = gv.Polygons(poly_data, vdims='BoroName', crs=ccrs.GOOGLE_MERCATOR)
tiles * polys
```

![image](https://user-images.githubusercontent.com/1550771/34910480-40b95868-f8ae-11e7-969a-299a373dd312.png)

<img width="810" alt="screen shot 2018-01-13 at 10 07 00 pm" src="https://user-images.githubusercontent.com/1550771/34910483-47b845f2-f8ae-11e7-90d0-681805b1bbc9.png">
