### PR TITLE
Implement xESMF based regridding operation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
         - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
         - source activate test-environment
       install:
-        - conda install -c conda-forge nose numpy matplotlib bokeh pandas scipy jupyter ipython param flake8 mock filelock iris cartopy xarray geopandas numpy shapely=1.6.3 gdal=2.2.3 libgdal=2.2.3 glib=2.55.0 gstreamer=1.8.0 --quiet
+        - conda install -c conda-forge nose numpy matplotlib bokeh pandas scipy jupyter ipython param flake8 mock filelock iris cartopy xarray geopandas numpy shapely=1.6.3 gdal=2.2.3 libgdal=2.2.3 glib=2.55.0 gstreamer=1.8.0 datashader --quiet
         - pip install coveralls
         - pip install git+https://github.com/ioam/holoviews.git
         - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ jobs:
         - python -c "import geoviews as gv; gv.sample_data('notebooks/user_guide/sample-data')"
         - python -c "import geoviews as gv; gv.sample_data('doc/sample-data')"
         - conda install -c conda-forge sphinx beautifulsoup4 graphviz
-		- conda install -c nesii/label/dev-esmf -c conda-forge esmpy
-		- pip install xesmf
+        - conda install -c nesii/label/dev-esmf -c conda-forge esmpy
+        - pip install xesmf
         - pip install nbsite
         - pip install sphinx_ioam_theme
         # TODO: should make this content available too rather than deleting it!

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ jobs:
         - python -c "import geoviews as gv; gv.sample_data('notebooks/user_guide/sample-data')"
         - python -c "import geoviews as gv; gv.sample_data('doc/sample-data')"
         - conda install -c conda-forge sphinx beautifulsoup4 graphviz
+		- conda install -c nesii/label/dev-esmf -c conda-forge esmpy
+		- pip install xesmf
         - pip install nbsite
         - pip install sphinx_ioam_theme
         # TODO: should make this content available too rather than deleting it!

--- a/geoviews/operation/__init__.py
+++ b/geoviews/operation/__init__.py
@@ -4,14 +4,14 @@ from holoviews.operation.stats import bivariate_kde
 
 from .. import element as gv_element
 from ..element import _Element
-from .projection import (
+from .projection import ( # noqa (API import)
     project_image, project_path, project_shape, project_points,
     project_graph, project_quadmesh, project
 )
 
 geo_ops = [contours, bivariate_kde]
 try:
-    from holoviews.operation.datashader import (
+    from holoviews.operation.datashader import (   
         ResamplingOperation, shade, stack, dynspread)
     geo_ops += [ResamplingOperation, shade, stack, dynspread]
 except:

--- a/geoviews/operation/__init__.py
+++ b/geoviews/operation/__init__.py
@@ -1,0 +1,54 @@
+from holoviews.core import Element
+from holoviews.operation.element import contours
+from holoviews.operation.stats import bivariate_kde
+
+from .. import element as gv_element
+from ..element import _Element
+from .projection import (
+    project_image, project_path, project_shape, project_points,
+    project_graph, project_quadmesh, project
+)
+
+geo_ops = [contours, bivariate_kde]
+try:
+    from holoviews.operation.datashader import (
+        ResamplingOperation, shade, stack, dynspread)
+    geo_ops += [ResamplingOperation, shade, stack, dynspread]
+except:
+    pass
+
+def convert_to_geotype(element, crs=None):
+    """
+    Converts a HoloViews element type to the equivalent GeoViews
+    element if given a coordinate reference system.
+    """
+    geotype = getattr(gv_element, type(element).__name__, None)
+    if crs is None or geotype is None or isinstance(element, _Element):
+        return element
+    return geotype(element, crs=crs)
+
+
+def find_crs(element):
+    """
+    Traverses the supplied object looking for coordinate reference
+    systems (crs). If multiple clashing reference systems are found
+    it will throw an error.
+    """
+    crss = element.traverse(lambda x: x.crs, [_Element])
+    crss = [crs for crs in crss if crs is not None]
+    if any(crss[0] != crs for crs in crss[1:] if crs is not None):
+        raise ValueError('Cannot datashade Elements in different '
+                         'coordinate reference systems.')
+    return {'crs': crss[0] if crss else None}
+
+
+def add_crs(element, **kwargs):
+    """
+    Converts any elements in the input to their equivalent geotypes
+    if given a coordinate reference system.
+    """
+    return element.map(lambda x: convert_to_geotype(x, kwargs.get('crs')), Element)
+
+for op in geo_ops:
+    op._preprocess_hooks = op._preprocess_hooks + [find_crs]
+    op._postprocess_hooks = op._postprocess_hooks + [add_crs]

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -3,66 +3,13 @@ import numpy as np
 
 from cartopy import crs as ccrs
 from cartopy.img_transform import warp_array, _determine_bounds
-from holoviews.core import Element
 from holoviews.core.util import cartesian_product, get_param_values
 from holoviews.operation import Operation
 from shapely.geometry import Polygon, LineString
 
-from . import element as gv_element
-from .element import (Image, Shape, Polygons, Path, Points, Contours,
-                      RGB, Graph, Nodes, EdgePaths, QuadMesh, VectorField,
-                      _Element)
-from .util import project_extents, geom_to_array
-
-geo_ops = []
-try:
-    from holoviews.operation.datashader import (
-        ResamplingOperation, shade, stack, dynspread)
-    geo_ops += [ResamplingOperation, shade, stack, dynspread]
-except:
-    pass
-
-from holoviews.operation.element import contours
-from holoviews.operation.stats import bivariate_kde
-
-geo_ops += [contours, bivariate_kde]
-
-def convert_to_geotype(element, crs=None):
-    """
-    Converts a HoloViews element type to the equivalent GeoViews
-    element if given a coordinate reference system.
-    """
-    geotype = getattr(gv_element, type(element).__name__, None)
-    if crs is None or geotype is None or isinstance(element, _Element):
-        return element
-    return geotype(element, crs=crs)
-
-
-def find_crs(element):
-    """
-    Traverses the supplied object looking for coordinate reference
-    systems (crs). If multiple clashing reference systems are found
-    it will throw an error.
-    """
-    crss = element.traverse(lambda x: x.crs, [_Element])
-    crss = [crs for crs in crss if crs is not None]
-    if any(crss[0] != crs for crs in crss[1:] if crs is not None):
-        raise ValueError('Cannot datashade Elements in different '
-                         'coordinate reference systems.')
-    return {'crs': crss[0] if crss else None}
-
-
-def add_crs(element, **kwargs):
-    """
-    Converts any elements in the input to their equivalent geotypes
-    if given a coordinate reference system.
-    """
-    return element.map(lambda x: convert_to_geotype(x, kwargs.get('crs')), Element)
-
-
-for op in geo_ops:
-    op._preprocess_hooks = op._preprocess_hooks + [find_crs]
-    op._postprocess_hooks = op._postprocess_hooks + [add_crs]
+from ..element import (Image, Shape, Polygons, Path, Points, Contours,
+                      RGB, Graph, Nodes, EdgePaths, QuadMesh, VectorField)
+from ..util import project_extents, geom_to_array
 
 
 class _project_operation(Operation):
@@ -254,8 +201,8 @@ class project_image(_project_operation):
         data = np.flipud(projected)
         bounds = (extents[0], extents[2], extents[1], extents[3])
         return img.clone(data, bounds=bounds, kdims=img.kdims,
-                         vdims=img.vdims, crs=proj)
-
+                         vdims=img.vdims, crs=proj, xdensity=None,
+                         ydensity=None)
 
     def _fast_process(self, element, key=None):
         # Project coordinates

--- a/geoviews/operation/regrid.py
+++ b/geoviews/operation/regrid.py
@@ -21,8 +21,10 @@ class weighted_regrid(regrid):
     Implements weighted regridding of rectilinear and curvilinear
     grids using the xESMF library, supporting all the ESMF regridding
     algorithms including bilinear, conservative and nearest neighbour
-    regridding. In addition to these different interpolation options
-    it supports
+    regridding. The operation will always store the sparse weight
+    matrix to disk and reuse the weights for later aggregations. To
+    delete the weight files call the clean_weight_files method on the
+    operation.
     """
 
     interpolation = param.ObjectSelector(default='bilinear',

--- a/geoviews/operation/regrid.py
+++ b/geoviews/operation/regrid.py
@@ -1,0 +1,77 @@
+import param
+import numpy as np
+import xarray as xr
+
+from holoviews.core.util import get_param_values
+from holoviews.element import Image as HvImage
+from holoviews.operation.datashader import regrid
+
+from ..element import Image, is_geographic
+
+
+class weighted_regrid(regrid):
+    """
+    Implements weighted regridding of rectilinear and curvilinear
+    grids using the xESMF library, supporting all the ESMF regridding
+    algorithms including bilinear, conservative and nearest neighbour
+    regridding. In addition to these different interpolation options
+    it supports
+    """
+
+    interpolation = param.ObjectSelector(default='bilinear',
+        objects=['bilinear', 'conservative', 'nearest_s2d', 'nearest_d2s'], doc="""
+        Interpolation method""")
+
+    reuse_weights = param.Boolean(default=True, doc="""
+        Whether the sparse regridding weights should be cached as a local
+        NetCDF file in the path defined by the file_pattern parameter.
+        Can provide considerable speedups when exploring a larger dataset.""")
+
+    file_pattern = param.String(default='{method}_{x_range}_{y_range}_{width}x{height}.nc',
+                                doc="""
+        The file pattern used to store the regridding weights when the
+        reuse_weights parameter is disabled. Note the files are not
+        cleared automatically so make sure you clean up the cached
+        files when you are done.""")
+
+    def _get_regridder(self, element):
+        try:
+            import xesmf as xe
+        except:
+            raise ImportError("xESMF library required for weighted regridding.")
+        x, y = element.kdims
+        info = self._get_sampling(element, x, y)
+        (x_range, y_range), _, (width, height), (xtype, ytype) = info
+        if x_range[0] > x_range[1]:
+            x_range = x_range[::-1]
+        element = element.select(**{x.name: x_range, y.name: y_range})
+        irregular = any(element.interface.irregular(element, d)
+                        for d in [x, y])
+        coord_opts = {'flat': False} if irregular else {'expanded': False}
+        coords = tuple(element.dimension_values(d, **coord_opts)
+                       for d in [x, y])
+        arrays = self._get_xarrays(element, coords, xtype, ytype)
+        ys = np.linspace(y_range[0], y_range[1], height)
+        xs = np.linspace(x_range[0], x_range[1], width)
+        ds_out = xr.Dataset({'lat': ys, 'lon': xs})
+        ds = xr.Dataset(arrays)
+        ds.rename({x.name: 'lon', y.name: 'lat'}, inplace=True)
+
+        x_range = str(tuple('%.3f' % r for r in x_range)).replace("'", '')
+        y_range = str(tuple('%.3f' % r for r in y_range)).replace("'", '')
+        filename = self.file_pattern.format(method=self.p.interpolation,
+                                            width=width, height=height,
+                                            x_range=x_range, y_range=y_range)
+        regridder = xe.Regridder(ds, ds_out, self.p.interpolation,
+                                 reuse_weights=self.p.reuse_weights,
+                                 filename=filename.replace(', ', '_'))
+        return regridder, arrays
+
+
+    def _process(self, element, key=None):
+        regridder, arrays = self._get_regridder(element)
+        ds = xr.Dataset({vd: regridder(arr) for vd, arr in arrays.items()})
+        params = dict(get_param_values(element), kdims=['lon', 'lat'])
+        if is_geographic(element):
+            return Image(ds, crs=element.crs, **params)
+        return HvImage(ds, **params)

--- a/geoviews/operation/regrid.py
+++ b/geoviews/operation/regrid.py
@@ -53,8 +53,7 @@ class weighted_regrid(regrid):
             tx, ty = self.p.target.kdims[:2]
             if issubclass(self.p.target.interface, XArrayInterface):
                 ds_out = self.p.target.data
-                ds_out.rename({tx.name: 'lon', ty.name: 'lat'},
-                              inplace=True)
+                ds_out = ds_out.rename({tx.name: 'lon', ty.name: 'lat'})
                 height, width = ds_out[tx.name].shape
             else:
                 xs = self.p.target.dimension_values(0, expanded=False)
@@ -97,8 +96,10 @@ class weighted_regrid(regrid):
 
     def _process(self, element, key=None):
         regridder, arrays = self._get_regridder(element)
+        x, y = element.kdims
         ds = xr.Dataset({vd: regridder(arr) for vd, arr in arrays.items()})
-        params = dict(get_param_values(element), kdims=['lon', 'lat'])
+        ds.rename({'lon': x.name, 'lat': y.name}, inplace=True)
+        params = get_param_values(element)
         if is_geographic(element):
             try:
                 return Image(ds, crs=element.crs, **params)

--- a/notebooks/user_guide/Resampling_Grids.ipynb
+++ b/notebooks/user_guide/Resampling_Grids.ipynb
@@ -1,0 +1,343 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cartopy.crs as ccrs\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import xarray as xr\n",
+    "import holoviews as hv\n",
+    "import geoviews as gv\n",
+    "import datashader as dsh\n",
+    "\n",
+    "hv.extension('bokeh')\n",
+    "\n",
+    "%opts QuadMesh Image [width=600 height=400 colorbar=True] Feature [apply_ranges=False]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In geographical applications grids and meshes of different kinds are very common and for visualization and analysis it is often very important to be able to regrid them in different ways. Regridding can refer both to upsampling and downsampling a grid or mesh, which is achieved through interpolation and aggregation respectively.\n",
+    "\n",
+    "Naive approaches to regridding treat the space as flat, which is often simpler but can also give incorrect results when working with a flat earth. In this user guide we will summarize how to work with different grid types including rectilinear, curvilinear grids and trimeshes. Additionally we will discuss different approaches to regridding working based on the assumption of a flat earth (using [datashader](http://datashader.org/)) and a spherical earth ([xESMF](http://xesmf.readthedocs.io/en/latest/Curvilinear_grid.html))."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rectilinear grids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rectilinear grids are one of the most standard formats and are defined by regularly sampled coordinates along the two axes. The ``air_temperature`` dataset provided by xarray and used throughout the GeoViews documentation provides a good example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.tutorial.load_dataset('air_temperature').isel(time=slice(0, 5))\n",
+    "# Ensure data is in range (-180, 180)\n",
+    "ds['lon'] = np.where(ds.lon>180, ds.lon-360, ds.lon)\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we already know from the [Gridded Dataset](./user_guide/Gridded_Datasets_II.ipynb) sections, an xarray of this kind can easily be wrapped in a GeoViews dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "gvds = gv.Dataset(ds)\n",
+    "gvds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also easily plot this data by using the ``.to`` method to create set of ``Image`` elements:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%opts Image (cmap='viridis') \n",
+    "images = gvds.to(gv.Image, ['lon', 'lat'], dynamic=True)\n",
+    "images * gv.feature.coastline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Datashader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from holoviews.operation.datashader import regrid\n",
+    "regrid(images, interpolation='linear') * gv.feature.coastline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### xESMF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoviews.operation.regrid import weighted_regrid\n",
+    "weighted_regrid(images, interpolation='nearest_s2d').redim.range(air=(230, 300)) * gv.feature.coastline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Curvilinear Grids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Curvilinear grids are another very common mesh type, which are usually defined by multi-dimensional coordinate arrays:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.tutorial.load_dataset('rasm')\n",
+    "# Adjust the longitudes so they are in the range -180 to 180\n",
+    "ds.xc.values[ds.xc.values>180] -= 360 \n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just like the rectilinear grids GeoViews understands this kind of data natively. So we again wrap this dataset in a ``gv.Dataset`` and define a fixed range for the ``Tair`` values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gvds = gv.Dataset(ds).redim.range(Tair=(-25, 25))\n",
+    "gvds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can plot this data directly as a ``gv.QuadMesh``, however this is generally quite slow, especially when we are working with bokeh where each grid point is rendered as a distinct polygon. We will therefore downsample the data by 4x along both dimensions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%opts Image QuadMesh (cmap='RdBu_r')\n",
+    "quadmeshes = gvds.to(gv.QuadMesh, ['xc', 'yc'], dynamic=True)\n",
+    "quadmeshes.map(lambda x: x.clone(x.data.Tair[::4, ::4]), gv.QuadMesh) * gv.feature.coastline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to explore the whole dataset we therefore don't have much of a choice except for regridding it onto a rectilinear grid, which can be rendered much more efficiently. Once again we have the option of using the datashader based approach or the more correct xESMF based approach."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Datashader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To regrid a ``QuadMesh`` using GeoViews we can import the ``rasterize`` operation. In the background the operation will convert the ``QuadMesh`` into a ``TriMesh``, which datashader understands. To optimize this conversion so it occurs only when aggregating an Image for the first time we can activate the ``precompute`` option. Additionally we have to define an aggregator, in this case to compute the mean ``Tair`` value in a pixel:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from holoviews.operation.datashader import rasterize\n",
+    "rasterize(quadmeshes, precompute=True, aggregator=dsh.mean('Tair')) * gv.feature.coastline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### xESMF"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The xESMF based approach stores generates a sparse weight matrix which weights each grid cell appropriately. Optionally this weight matrix can be cached to disk to speed up subsequent aggregation, to enable this optimization enable ``reuse_weights`` (and optionally define a custom filepattern)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from geoviews.operation.regrid import weighted_regrid\n",
+    "weighted_regrid(quadmeshes, reuse_weights=True) * gv.feature.coastline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TriMesh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another commonly used mesh/grid type are trimeshes, here we will load a 3dm file and demonstrate how to visualize it using HoloViews:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fpath = './Example_Meshes/Chesapeake_and_Delaware_Bays.3dm'\n",
+    "all_df = pd.read_table(fpath, delim_whitespace=True, header=None, skiprows=1,\n",
+    "                       names=('row_type', 'cmp1', 'cmp2', 'cmp3', 'val'), index_col=1)\n",
+    "all_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before we can work with this data we have to process it a bit, splitting the data into vertices and triangles:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conns = all_df[all_df['row_type'].str.lower() == 'e3t'][['cmp1', 'cmp2', 'cmp3']].values.astype(int) - 1\n",
+    "pts = all_df[all_df['row_type'].str.lower() == 'nd'][['cmp1', 'cmp2', 'cmp3']].values.astype(float)\n",
+    "pts[:, 2] *= -1\n",
+    "verts = pd.DataFrame(pts, columns=['x', 'y', 'z'])\n",
+    "tris = pd.DataFrame(conns, columns=['v0', 'v1', 'v2'])\n",
+    "print(\"Triangles: %d\\nVertices: %d\" % (len(tris), len(verts)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Datashader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a reasonably large mesh with >1 million triangles and cannot easily be displayed directly with matplotlib or especially bokeh. Therefore we will once again regrid this dataset onto a rectilinear grid. Additionally, to speed up plotting of meshes, we can do two things, first of all since all data displayed with bokeh is first projected to Web Mercator coordinates we can project the mesh immediately, secondly we can use the ``precompute`` during rasterization, which will cache an optimized mesh datastructure:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Image [width=800 height=500] (cmap='viridis')\n",
+    "trimesh = gv.operation.project_graph(gv.TriMesh((tris, verts)))\n",
+    "tiles = gv.WMTS('https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png')\n",
+    "tiles * rasterize(trimesh, precompute=True, aggregator=dsh.mean('z'))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/user_guide/Resampling_Grids.ipynb
+++ b/notebooks/user_guide/Resampling_Grids.ipynb
@@ -14,7 +14,7 @@
     "import geoviews as gv\n",
     "import datashader as dsh\n",
     "\n",
-    "hv.extension('bokeh')\n",
+    "hv.extension('bokeh', 'matplotlib')\n",
     "\n",
     "%opts QuadMesh Image [width=600 height=400 colorbar=True] Feature [apply_ranges=False]"
    ]
@@ -23,9 +23,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In geographical applications grids and meshes of different kinds are very common and for visualization and analysis it is often very important to be able to regrid them in different ways. Regridding can refer both to upsampling and downsampling a grid or mesh, which is achieved through interpolation and aggregation respectively.\n",
+    "In geographical applications grids and meshes of different kinds are very common and for visualization and analysis it is often very important to be able to resample them in different ways. Regridding can refer both to upsampling and downsampling a grid or mesh, which is achieved through interpolation and aggregation.\n",
     "\n",
-    "Naive approaches to regridding treat the space as flat, which is often simpler but can also give incorrect results when working with a flat earth. In this user guide we will summarize how to work with different grid types including rectilinear, curvilinear grids and trimeshes. Additionally we will discuss different approaches to regridding working based on the assumption of a flat earth (using [datashader](http://datashader.org/)) and a spherical earth ([xESMF](http://xesmf.readthedocs.io/en/latest/Curvilinear_grid.html))."
+    "Naive approaches to regridding treat the space as flat, which is often simpler but can also give incorrect results when working with a spherical space such as the earth. In this user guide we will summarize how to work with different grid types including rectilinear, curvilinear grids and trimeshes. Additionally we will discuss different approaches to regridding working based on the assumption of a flat earth (using [datashader](http://datashader.org/)) and a spherical earth ([xESMF](http://xesmf.readthedocs.io/en/latest/Curvilinear_grid.html))."
    ]
   },
   {
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.tutorial.load_dataset('air_temperature').isel(time=slice(0, 5))\n",
+    "ds = xr.tutorial.load_dataset('air_temperature').isel(time=slice(0, 100))\n",
     "# Ensure data is in range (-180, 180)\n",
     "ds['lon'] = np.where(ds.lon>180, ds.lon-360, ds.lon)\n",
     "ds"
@@ -69,7 +69,7 @@
    },
    "outputs": [],
    "source": [
-    "gvds = gv.Dataset(ds)\n",
+    "gvds = gv.Dataset(ds).redim.range(air=(230, 300))\n",
     "gvds"
    ]
   },
@@ -77,7 +77,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also easily plot this data by using the ``.to`` method to create set of ``Image`` elements:"
+    "We can also easily plot this data by using the ``.to`` method to group the data into a set of ``Image`` elements indexed by 'time':"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "images = gvds.to(gv.Image, ['lon', 'lat'], dynamic=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is important to note that if we look at the longitude coordinates above we can see that they are defined in the range (0, 360), while GeoViews generally expects it to be in the range (-180, 180). To correct this we have one of two options:\n",
+    "\n",
+    "1. We use the ``project_image`` operation to correct this.\n",
+    "\n",
+    "2. We explicitly adjust the coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option 1\n",
+    "images = gv.operation.project_image(images, projection=ccrs.PlateCarree())\n",
+    "\n",
+    "# Option 2\n",
+    "# ds['lon'] = np.where(ds.lon>180, ds.lon-360, ds.lon)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we are ready to display the data. Note that throughout this user guide we will be using Bokeh but we could easily switch to matplotlib if needed."
    ]
   },
   {
@@ -87,7 +127,6 @@
    "outputs": [],
    "source": [
     "%opts Image (cmap='viridis') \n",
-    "images = gvds.to(gv.Image, ['lon', 'lat'], dynamic=True)\n",
     "images * gv.feature.coastline"
    ]
   },
@@ -99,13 +138,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "HoloViews provides high-level wrappers around the datashader library, which make it possible to quickly resample or aggregate datasets of different kinds. Datashader knows nothing about non-flat coordinate systems, but provides a very fast, parallelized regridding operation for rectilinear grids. Here we will import the ``regrid`` operation and pass it our stack of images from above. While this dataset is fairly small and regridding will actually upsample the image to match the dimensions of the plot, ``regrid`` can very quickly downsample very large datasets.\n",
+    "\n",
+    "One important thing to note about the resampling operations we will be working with in this user guide is that they are dynamic and linked to the plot dimensions and axis ranges. This means that whenever we zoom or pan the data will be resampled. If we want to disable this linked behavior and supply an explicit width and height we can disable the streams by passing ``streams=[]`` as a keyword argument."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from holoviews.operation.datashader import regrid\n",
-    "regrid(images, interpolation='linear') * gv.feature.coastline"
+    "regrid(images) * gv.feature.coastline"
    ]
   },
   {
@@ -116,13 +164,64 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The xESMF library is specifically designed to provide an easy way to correctly resample grids defined in geographic coordinate systems and differs significantly from the simpler approach used by datashader, which applies simple upsampling and downsampling. xESMF is a wrapper around the [ESMF regridding algorithms](https://www.earthsystemcog.org/projects/esmf/regridding), which compute an interpolation weight matrix which is applied to remap the values of the source grid onto the destination grid. \n",
+    "\n",
+    "In GeoViews these algorithms are made available via the simple ``weighted_regrid`` operation, which supports the different interpolation modes including: 'bilinear', 'nearest_s2d', 'nearest_d2s' and 'conservative'. Since generating the sparse weight matrix takes much longer than applying it the operation will cache the weight matrix on disk for later use, this optimization can be disabled via the ``reuse_weights`` parameter or customized by defining a custom ``file_pattern``."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from geoviews.operation.regrid import weighted_regrid\n",
-    "weighted_regrid(images, interpolation='nearest_s2d').redim.range(air=(230, 300)) * gv.feature.coastline"
+    "weighted_regrid(images) * gv.feature.coastline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Onto an existing grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The operation also allows us to define a target grid, which we can either define manually or by using a utility provided by the xESMF library. Here we will define a $2^{\\circ}x1^{\\circ}$ grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xesmf as xe\n",
+    "grid = xe.util.grid_2d(-160, -35, 2, 15, 70, 2)\n",
+    "grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since the grid has 2D coordinate arrays the regridded data will be wrapped in and displayed as a QuadMesh:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target = gv.Dataset(grid, kdims=['lon', 'lat'])\n",
+    "weighted_regrid(images, target=target, streams=[])"
    ]
   },
   {
@@ -172,7 +271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can plot this data directly as a ``gv.QuadMesh``, however this is generally quite slow, especially when we are working with bokeh where each grid point is rendered as a distinct polygon. We will therefore downsample the data by 4x along both dimensions:"
+    "Now we can plot this data directly as a ``gv.QuadMesh``, however this is generally quite slow, especially when we are working with bokeh where each grid point is rendered as a distinct polygon. We will therefore downsample the data by a factor of 3 along both dimensions:"
    ]
   },
   {
@@ -183,14 +282,32 @@
    "source": [
     "%opts Image QuadMesh (cmap='RdBu_r')\n",
     "quadmeshes = gvds.to(gv.QuadMesh, ['xc', 'yc'], dynamic=True)\n",
-    "quadmeshes.map(lambda x: x.clone(x.data.Tair[::4, ::4]), gv.QuadMesh) * gv.feature.coastline"
+    "quadmeshes.map(lambda x: x.clone(x.data.Tair[::3, ::3]), gv.QuadMesh) * gv.feature.coastline"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we want to explore the whole dataset we therefore don't have much of a choice except for regridding it onto a rectilinear grid, which can be rendered much more efficiently. Once again we have the option of using the datashader based approach or the more correct xESMF based approach."
+    "The problem is less severe when plotting using matplotlib but even then plotting can be fairly slow given a large enough mesh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%output backend='matplotlib' size=300\n",
+    "%%opts QuadMesh (cmap='RdBu_r')\n",
+    "quadmeshes * gv.feature.coastline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to explore a very large grid it therefore often makes sense to resample the data onto a rectilinear grid, which can be rendered much more efficiently. Once again we have the option of using the datashader based approach or the more correct xESMF based approach."
    ]
   },
   {
@@ -204,7 +321,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To regrid a ``QuadMesh`` using GeoViews we can import the ``rasterize`` operation. In the background the operation will convert the ``QuadMesh`` into a ``TriMesh``, which datashader understands. To optimize this conversion so it occurs only when aggregating an Image for the first time we can activate the ``precompute`` option. Additionally we have to define an aggregator, in this case to compute the mean ``Tair`` value in a pixel:"
+    "To regrid a ``QuadMesh`` using GeoViews we can import the ``rasterize`` operation. In the background the operation will convert the ``QuadMesh`` into a ``TriMesh``, which datashader understands. To optimize this conversion so it occurs only when aggregating the ``QuadMesh`` for the first time we can activate the ``precompute`` option. Additionally we have to define an aggregator, in this case to compute the mean ``Tair`` value in a pixel:"
    ]
   },
   {
@@ -228,7 +345,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The xESMF based approach stores generates a sparse weight matrix which weights each grid cell appropriately. Optionally this weight matrix can be cached to disk to speed up subsequent aggregation, to enable this optimization enable ``reuse_weights`` (and optionally define a custom filepattern)."
+    "Now we will once again use the xESMF based regridding for which we can still use the ``weighted_regrid`` operation, since it supports both rectilinear and curvilinear grids. Since the original data doesn't have a very high resolution we will also disable the ``streams`` linking the operation to the plot dimensions and axis ranges."
    ]
   },
   {
@@ -240,7 +357,7 @@
    "outputs": [],
    "source": [
     "from geoviews.operation.regrid import weighted_regrid\n",
-    "weighted_regrid(quadmeshes, reuse_weights=True) * gv.feature.coastline"
+    "weighted_regrid(quadmeshes, streams=[]) * gv.feature.coastline"
    ]
   },
   {

--- a/notebooks/user_guide/Resampling_Grids.ipynb
+++ b/notebooks/user_guide/Resampling_Grids.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "In geographical applications grids and meshes of different kinds are very common and for visualization and analysis it is often very important to be able to resample them in different ways. Regridding can refer both to upsampling and downsampling a grid or mesh, which is achieved through interpolation and aggregation.\n",
     "\n",
-    "Naive approaches to regridding treat the space as flat, which is often simpler but can also give incorrect results when working with a spherical space such as the earth. In this user guide we will summarize how to work with different grid types including rectilinear, curvilinear grids and trimeshes. Additionally we will discuss different approaches to regridding working based on the assumption of a flat earth (using [datashader](http://datashader.org/)) and a spherical earth ([xESMF](http://xesmf.readthedocs.io/en/latest/Curvilinear_grid.html))."
+    "Naive approaches to regridding treat the space as flat, which is often simpler but can also give less accurate results when working with a spherical space such as the earth. In this user guide we will summarize how to work with different grid types including rectilinear, curvilinear grids and trimeshes. Additionally we will discuss different approaches to regridding working based on the assumption of a flat earth (using [datashader](http://datashader.org/)) and a spherical earth ([xESMF](http://xesmf.readthedocs.io/en/latest/Curvilinear_grid.html))."
    ]
   },
   {
@@ -49,8 +49,6 @@
    "outputs": [],
    "source": [
     "ds = xr.tutorial.load_dataset('air_temperature').isel(time=slice(0, 100))\n",
-    "# Ensure data is in range (-180, 180)\n",
-    "ds['lon'] = np.where(ds.lon>180, ds.lon-360, ds.lon)\n",
     "ds"
    ]
   },
@@ -93,11 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is important to note that if we look at the longitude coordinates above we can see that they are defined in the range (0, 360), while GeoViews generally expects it to be in the range (-180, 180). To correct this we have one of two options:\n",
-    "\n",
-    "1. We use the ``project_image`` operation to correct this.\n",
-    "\n",
-    "2. We explicitly adjust the coordinates."
+    "It is important to note that if we look at the longitude coordinates above we can see that they are defined in the range (0, 360), while GeoViews generally expects it to be in the range (-180, 180). To correct this we can apply a simple fix:"
    ]
   },
   {
@@ -106,11 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Option 1\n",
-    "images = gv.operation.project_image(images, projection=ccrs.PlateCarree())\n",
-    "\n",
-    "# Option 2\n",
-    "# ds['lon'] = np.where(ds.lon>180, ds.lon-360, ds.lon)"
+    "ds['lon'] = np.where(ds.lon>180, ds.lon-360, ds.lon)"
    ]
   },
   {
@@ -167,9 +157,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The xESMF library is specifically designed to provide an easy way to correctly resample grids defined in geographic coordinate systems and differs significantly from the simpler approach used by datashader, which applies simple upsampling and downsampling. xESMF is a wrapper around the [ESMF regridding algorithms](https://www.earthsystemcog.org/projects/esmf/regridding), which compute an interpolation weight matrix which is applied to remap the values of the source grid onto the destination grid. \n",
+    "The xESMF library is specifically designed to provide an easy way to accurately resample grids defined in geographic coordinate systems and differs significantly from the simpler approach used by datashader, which applies simple upsampling and downsampling. xESMF is a wrapper around the [ESMF regridding algorithms](https://www.earthsystemcog.org/projects/esmf/regridding), which compute an interpolation weight matrix which is applied to remap the values of the source grid onto the destination grid. \n",
     "\n",
-    "In GeoViews these algorithms are made available via the simple ``weighted_regrid`` operation, which supports the different interpolation modes including: 'bilinear', 'nearest_s2d', 'nearest_d2s' and 'conservative'. Since generating the sparse weight matrix takes much longer than applying it the operation will cache the weight matrix on disk for later use, this optimization can be disabled via the ``reuse_weights`` parameter or customized by defining a custom ``file_pattern``."
+    "In GeoViews these algorithms are made available via the ``weighted_regrid`` operation, which supports the different interpolation modes including: 'bilinear', 'nearest_s2d', 'nearest_d2s' and 'conservative'. Since generating the sparse weight matrix takes much longer than applying it the operation will cache the weight matrix on disk for later use; this optimization can be disabled via the ``reuse_weights`` parameter or customized by defining a custom ``file_pattern``."
    ]
   },
   {
@@ -186,6 +176,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Since this operation creates local weight files we will want to clean up after ourselves once we are done, to do so we can call the ``weighted_regrid.clean_weight_files`` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weighted_regrid.clean_weight_files()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Onto an existing grid"
    ]
   },
@@ -193,7 +199,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The operation also allows us to define a target grid, which we can either define manually or by using a utility provided by the xESMF library. Here we will define a $2^{\\circ}x1^{\\circ}$ grid."
+    "The operation also allows us to define a target grid, which we can either define manually or by using a utility provided by the xESMF library. Here we will define a $2^{\\circ}\\times2^{\\circ}$ grid."
    ]
   },
   {
@@ -221,7 +227,7 @@
    "outputs": [],
    "source": [
     "target = gv.Dataset(grid, kdims=['lon', 'lat'])\n",
-    "weighted_regrid(images, target=target, streams=[])"
+    "weighted_regrid(images, target=target, streams=[]) * gv.feature.coastline"
    ]
   },
   {
@@ -254,7 +260,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Just like the rectilinear grids GeoViews understands this kind of data natively. So we again wrap this dataset in a ``gv.Dataset`` and define a fixed range for the ``Tair`` values:"
+    "Just like the rectilinear grids GeoViews understands this kind of data natively. So we again wrap this dataset in a ``gv.Dataset`` and define a fixed range for the air teperature (``Tair``) values:"
    ]
   },
   {
@@ -307,7 +313,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we want to explore a very large grid it therefore often makes sense to resample the data onto a rectilinear grid, which can be rendered much more efficiently. Once again we have the option of using the datashader based approach or the more correct xESMF based approach."
+    "If we want to explore a very large grid it therefore often makes sense to resample the data onto a rectilinear grid, which can be rendered much more efficiently. Once again we have the option of using the datashader based approach or the more accurate xESMF based approach."
    ]
   },
   {
@@ -364,6 +370,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Finally lets clean up after ourselves one last time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weighted_regrid.clean_weight_files()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# TriMesh"
    ]
   },
@@ -371,7 +393,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another commonly used mesh/grid type are trimeshes, here we will load a 3dm file and demonstrate how to visualize it using HoloViews:"
+    "Another commonly used mesh/grid type are trimeshes defined as a set of edges and vertices. Here we will load a 3dm file and demonstrate how to visualize it using HoloViews:"
    ]
   },
   {
@@ -418,7 +440,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is a reasonably large mesh with >1 million triangles and cannot easily be displayed directly with matplotlib or especially bokeh. Therefore we will once again regrid this dataset onto a rectilinear grid. Additionally, to speed up plotting of meshes, we can do two things, first of all since all data displayed with bokeh is first projected to Web Mercator coordinates we can project the mesh immediately, secondly we can use the ``precompute`` during rasterization, which will cache an optimized mesh datastructure:"
+    "This is a reasonably large mesh with >1 million triangles and cannot easily be displayed directly with matplotlib or especially bokeh. Therefore we will once again regrid this dataset onto a rectilinear grid. Additionally, to speed up plotting of meshes, we can do two things: first of all since all data displayed with bokeh is first projected to Web Mercator coordinates we can project the mesh immediately; secondly, we can use the ``precompute`` during rasterization, which will cache an optimized mesh datastructure:"
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup_args.update(dict(
     packages = ["geoviews",
                 "geoviews.data",
                 "geoviews.element",
+                "geoviews.operation",
                 "geoviews.plotting",
                 "geoviews.plotting.bokeh",
                 "geoviews.plotting.mpl"],


### PR DESCRIPTION
Adds a [xESMF](xesmf.readthedocs.io) based regridding operation along with a user guide on how to use it. Depends on https://github.com/ioam/holoviews/pull/2265. The draft user guide can be seen here: https://anaconda.org/philippjfr/resampling_grids/notebook