### PR TITLE
created stand-alone scripts that reproduce the plots in the docs

### DIFF
--- a/notebooks/user_guide/Geometries.ipynb
+++ b/notebooks/user_guide/Geometries.ipynb
@@ -75,8 +75,17 @@
    "outputs": [],
    "source": [
     "%%output backend='bokeh'\n",
-    "%%opts Feature [scale='110m']\n",
-    "gf.ocean * gf.land() * gv.Feature(graticules, group='Lines').opts(plot=dict(scale='110m'))"
+    "%%opts Feature.Land.110m [scale='110m']\n",
+    "%%opts Feature.Land.50m [scale='50m']\n",
+    "(gf.ocean * gf.land().relabel(label='110m') * gv.Feature(graticules, group='Lines') + \n",
+    "     gf.ocean * gf.land().relabel(label='50m') * gv.Feature(graticules, group='Lines'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "zoom in using the bokeh zoom widget and you should see that the right hand panel is using a higher resultion dataset for the land feature"
    ]
   },
   {

--- a/notebooks/user_guide/Geometries.py
+++ b/notebooks/user_guide/Geometries.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import numpy as np
 import holoviews as hv
 import geoviews as gv
 import geoviews.feature as gf

--- a/notebooks/user_guide/Geometries.py
+++ b/notebooks/user_guide/Geometries.py
@@ -1,0 +1,222 @@
+import pandas as pd
+import numpy as np
+import holoviews as hv
+import geoviews as gv
+import geoviews.feature as gf
+import cartopy
+import cartopy.feature as cf
+from cartopy import crs as ccrs
+import geopandas as gpd
+
+"""
+The following examples were taken from
+http://geo.holoviews.org/user_guide/Geometries.html
+
+This script is designed to be run by the python interpreter rather
+than in a notebook.
+Each function has been designed as a stand-alone example.
+
+Typical modifications when moving from notebook to script include:
+    The need to create a renderer with a chosen backend.
+    e.g. renderer = hv.renderer('matplotlib')
+
+    plots are saved using render.save method.
+    e.g. renderer.save(obj, 'my_filename')
+
+    instead of ipython magics for controlling how elements look
+    options are passed using the .opts() methods.
+    below is an ipython cell magic format example
+    %opts Image {+framewise} [colorbar=True] Curve [xrotation=60]
+
+    when applying the above options globally you would do
+    hv.opts("Image {+framewise} [colorbar=True] Curve [xrotation=60]")
+
+    if you want to apply the options just to the object you would do
+    obj.opts("Image {+framewise} [colorbar=True] Curve [xrotation=60]")
+
+    Note that the .opts() method can also take a dictionary as an arg
+    but for ease of use the string format is preferred.
+"""
+
+def geoviews_features():
+    """
+    geoviews features example
+    using matplotlib as a backend so we can save as svg
+    """
+
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+    renderer.dpi = 120
+
+    features = (gf.ocean + gf.land + gf.ocean * gf.land * gf.coastline * gf.borders).cols(3)
+    renderer.save(features, 'geoviews_features', fmt='svg')
+
+
+def natural_earth_features():
+    """
+    load custom NaturalEarthFeatures such as graticules at 30 intervals
+    """
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+    renderer.dpi = 120
+
+    graticules = cf.NaturalEarthFeature(
+        category='physical', name='graticules_30', scale='110m')
+    features = gf.ocean * gf.land() * gv.Feature(
+        graticules, group='Lines') * gf.borders * gf.coastline
+
+    # define how the Lines element will look, will use a dictionary to
+    # show how it is done but later we will use the string fromat
+    opts = {
+        'Feature.Lines': {
+            'plot': dict(projection=ccrs.Robinson()),
+            'style': dict(facecolor='none', edgecolor='gray')
+        }
+    }
+
+    renderer.save(features, 'natural_earth_features', fmt='svg', options=opts)
+
+
+def feature_scale():
+    """
+    set the scale of features in cartopy.
+    use bokeh as the backend so we can zoom
+
+    This plot is slightly different to that on the website as it
+    has been modified to show how scale works on land feature
+    """
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+    # hv.opts applies options globally, later we will see that we can
+    # apply our options to a single element/object. here we are
+    # still using the dictionary format
+    hv.opts({'Feature.Land.110m': {'plot': dict(scale='110m')}})
+    hv.opts({'Feature.Land.50m': {'plot': dict(scale='50m')}})
+
+    graticules = cf.NaturalEarthFeature(
+        category='physical', name='graticules_30', scale='110m')
+
+    feat_110m = gf.ocean * gf.land().relabel(label='110m') * gv.Feature(graticules, group='Lines')
+    feat_50m = gf.ocean * gf.land().relabel(label='50m') * gv.Feature(graticules, group='Lines')
+
+    img = feat_110m + feat_50m
+    renderer.save(img, 'feature_scale')
+
+def shape_files():
+    """
+    Shape example: plotting Australia with matplotlib and overlaying
+    Alice Springs point.
+    """
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+
+    # use string format for opts, much easier especially later when
+    # we have more options to set
+    opts = "Points (color='black')"
+    hv.opts(opts)
+
+    land_geoms = list(gf.land.data.geometries())
+    australia = gv.Shape(land_geoms[21], crs=ccrs.PlateCarree())
+    img = (australia * gv.Points([(133.870,-23.700)]) 
+            * gv.Text(133.870,-21.5, 'Alice Springs', crs=ccrs.PlateCarree()))
+    renderer.save(img, 'Alice_Springs')
+
+def NdOverlay():
+    """
+    creating an NdOverlay
+    """
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+
+    land_geoms = list(gf.land.data.geometries())
+
+    img = hv.NdOverlay({i: gv.Shape(s, crs=ccrs.PlateCarree()) for i, s in enumerate(land_geoms)})
+
+    # apply options locally by supplying them to the renderer
+    renderer.save(img, 'ndoverlay', options={'NdOverlay': {'plot': dict(aspect=2)}})
+
+def UK_electoral_boundaries():
+    """
+    read a shape file and plot the UK electoral boundaries
+    """
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+
+    shapefile = './assets/boundaries/boundaries.shp'
+    shp = gv.Shape.from_shapefile(shapefile, crs=ccrs.PlateCarree())
+    renderer.save(shp, 'UK_electoral_boundaries')
+
+def choropleth():
+    """
+    Create a choropleth map using shape file and referendum data (pandas)
+
+    using bokeh backend
+    """
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+
+    shapefile = './assets/boundaries/boundaries.shp'
+    shapes = cartopy.io.shapereader.Reader(shapefile)
+
+    referendum = pd.read_csv('./assets/referendum.csv')
+    referendum = hv.Dataset(referendum)
+
+    img = gv.Shape.from_records(shapes.records(), referendum, on='code',
+            value='leaveVoteshare', index=['name', 'regionName'],
+            crs=ccrs.PlateCarree())
+
+    # apply options locally using the opts method
+    opts = {'Shape':{'style':dict(cmap='viridis')}}
+    renderer.save(img.opts(opts), 'chloropleth')
+
+def geopandas():
+    """
+    We can simply pass the GeoPandas DataFrame to a Polygons,
+    Path or Contours element and it will plot the data for us.
+    The Contours and Polygons will automatically color the data
+    by the first specified value dimension defined by the vdims keyword
+    (the geometries may be colored by any dimension using the 
+    color_index plot option):
+
+    using matplotlib backend
+    """
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+
+    world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
+
+    # note we cannot pass the projection or size into the .opts() method
+    renderer.size = 250
+    img = gv.Polygons(world, vdims='pop_est')(plot=dict(projection=ccrs.Robinson()))
+    renderer.save(img, 'geopandas', fmt='svg')
+
+def bokeh_hover_tools():
+    """
+    geopandas example with bokeh backend and hover tool
+
+    Geometries can be displayed using both matplotlib and bokeh,
+    here we will switch to bokeh allowing us to color by a categorical
+    variable ( continent ) and activating the hover tool to reveal
+    information about the plot.
+    """
+    hv.extension('bokeh')
+    renderer = hv.renderer('bokeh')
+
+    world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
+
+    opts = "Polygons [width=600 height=500 tools=['hover']] (cmap='tab20')"
+    vdims = ['continent',  'name', 'pop_est']
+    img = gv.Polygons(world, vdims=vdims).redim.range(Latitude=(-60, 90))
+    img = img.opts(opts)
+    renderer.save(img, 'world_map_with_hover')
+
+if __name__ == '__main__':
+    geoviews_features()
+    natural_earth_features()
+    feature_scale()
+    shape_files()
+    NdOverlay()
+    UK_electoral_boundaries()
+    choropleth()
+    geopandas()
+    bokeh_hover_tools()

--- a/notebooks/user_guide/Gridded_Datasets_I.py
+++ b/notebooks/user_guide/Gridded_Datasets_I.py
@@ -1,0 +1,169 @@
+import iris
+import numpy as np
+import xarray as xr
+import holoviews as hv
+import geoviews as gv
+import geoviews.feature as gf
+from cartopy import crs
+
+"""
+The following examples were taken from
+http://geoviews.org/user_guide/Gridded_Datasets_I.html
+
+This script is designed to be run by the python interpreter rather
+than in a notebook.
+
+Typical modifications when moving from notebook to script include:
+    The need to create a renderer with a chosen backend.
+    e.g. renderer = hv.renderer('matplotlib')
+
+    plots are saved using render.save method.
+    e.g. renderer.save(obj, 'my_filename')
+
+    instead of ipython magics for controlling how elements look
+    options are passed using the .opts() methods.
+    below is an ipython cell magic format example
+    %opts Image {+framewise} [colorbar=True] Curve [xrotation=60]
+
+    when applying the above options globally you would do
+    hv.opts("Image {+framewise} [colorbar=True] Curve [xrotation=60]")
+
+    if you want to apply the options just to the object you would do
+    obj.opts("Image {+framewise} [colorbar=True] Curve [xrotation=60]")
+
+    Note that the .opts() method can also take a dictionary as an arg
+    but for ease of use the string format is preferred.
+"""
+
+hv.extension('matplotlib', 'bokeh')
+renderer = hv.renderer('matplotlib')
+
+def set_globals():
+    # Let's start by setting some normalization options
+    # always enable colorbars for the elements we will be displaying:
+    hv.opts('Image {+framewise} [colorbar=True] Curve [xrotation=60]')
+
+    # specify the maximum number of frames we will display
+    hv.output(max_frames=1000)
+
+def load_data():
+    """
+    most of the examples load this dataset so lets turn it into
+    a function
+    """
+    # load the dataset via xarray
+    xr_ensemble = xr.open_dataset('./sample-data/ensemble.nc')
+
+    # load the dataset via Iris
+    iris.FUTURE.netcdf_promote=True
+    iris_ensemble = iris.load_cube('./sample-data/ensemble.nc')
+
+    # wrap the data in a GeoViews Dataset
+    kdims = ['time', 'longitude', 'latitude']
+    vdims = ['surface_temperature']
+    xr_dataset = gv.Dataset(xr_ensemble, kdims=kdims, vdims=vdims, crs=crs.PlateCarree())
+    iris_dataset = gv.Dataset(iris_ensemble, kdims=kdims, vdims=vdims)
+
+    # improve the formatting of dates on the xarray dataset
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+    return xr_dataset, iris_dataset
+
+def simple_example1():
+    """
+    create a holomap using the xarray dataset
+    """
+
+    xr_dataset, iris_dataset = load_data()
+    img_xr = xr_dataset.to(gv.Image, ['longitude', 'latitude'])
+    renderer.save(img_xr, 'simple_example_1_xr')
+
+def simple_example2():
+    """
+    create a holomap using the iris dataset
+    """
+
+    xr_dataset, iris_dataset = load_data()
+    img_iris = iris_dataset.to(gv.Image, ['longitude', 'latitude'])
+    renderer.save(img_iris, 'simple_example_2_iris')
+
+def simple_example3():
+    """
+    Holomap combiend with single frame
+    """
+
+    xr_dataset, iris_dataset = load_data()
+    air_temperature = gv.Dataset(xr.open_dataset('./sample-data/pre-industrial.nc'),
+            kdims=['longitude', 'latitude'], group='Pre-industrial air temperature',
+            vdims=['air_temperature'], crs=crs.PlateCarree())
+
+    img = (xr_dataset.to.image(['longitude', 'latitude']) +
+            air_temperature.to.image(['longitude', 'latitude']))
+    renderer.save(img, 'simple_example_3')
+
+def simple_example4():
+    """
+    Overlay point on holomap and combine with curve plot
+    """
+
+    xr_dataset, iris_dataset = load_data()
+    opts_crv = "Curve [aspect=2 xticks=4 xrotation=15]"
+    opts_pnt = " Points (color='k')"
+    temp_curve = hv.Curve(xr_dataset.select(longitude=0, latitude=10),
+            kdims=['time']).opts(opts_crv)
+
+    temp_map = (xr_dataset.to(gv.Image,['longitude', 'latitude'])
+            * gv.Points([(0,10)], crs=crs.PlateCarree()).opts(opts_pnt))
+
+    img = temp_map + temp_curve
+    renderer.save(img, 'simple_example_4')
+
+def simple_example5():
+    """
+    Overlaying data with framewize normalization
+    """
+
+    xr_dataset, iris_dataset = load_data()
+    opts_img = "Image (cmap='Greens')"
+    opts_ov = "Overlay [xaxis=None yaxis=None]"
+    img = (xr_dataset.to.image(['longitude', 'latitude']).opts(opts_img)
+            * gf.coastline).opts(opts_ov)
+
+    opts_proj = {'Image': {'plot':dict(projection=crs.Geostationary())}}
+    renderer.save(img, 'simple_example_5', options=opts_proj)
+
+def simple_example6():
+    """
+    Overlaying data with normalization set by redim
+    use 300 and max_surface_temp for the normalization range
+    """
+
+    xr_dataset, iris_dataset = load_data()
+    opts_img = "Image (cmap='Greens')"
+    opts_ov = "Overlay [xaxis=None yaxis=None]"
+    max_surface_temp = xr_dataset.range('surface_temperature')[1]
+    print(max_surface_temp)
+    ds_redim = xr_dataset.redim(surface_temperature=dict(range=(300, max_surface_temp)))
+    img = (ds_redim.to(gv.Image,['longitude', 'latitude']).opts(opts_img)
+            * gf.coastline)
+
+    opts_proj = {'Image': {'plot':dict(projection=crs.Geostationary())}}
+    renderer.save(img.opts(opts_ov), 'simple_example_6', options=opts_proj)
+
+def simple_example7():
+    """
+    Filled Contours example
+    """
+    xr_dataset, iris_dataset = load_data()
+    img = xr_dataset.to(gv.FilledContours,['longitude', 'latitude']) * gf.coastline
+    renderer.save(img, 'simple_example_7')
+
+if __name__ == '__main__':
+    set_globals()
+    simple_example1()
+    simple_example2()
+    simple_example3()
+    simple_example4()
+    simple_example5()
+    simple_example6()
+    simple_example7()
+

--- a/notebooks/user_guide/Gridded_Datasets_II.py
+++ b/notebooks/user_guide/Gridded_Datasets_II.py
@@ -1,0 +1,293 @@
+import numpy as np
+import xarray as xr
+import holoviews as hv
+import geoviews as gv
+import geoviews.feature as gf
+from cartopy import crs as ccrs
+from bokeh.plotting import curdoc, save, output_file
+
+"""
+The following examples were taken from
+http://geoviews.org/user_guide/Gridded_Datasets_II.html
+
+This script is designed to be run by the python interpreter rather
+than in a notebook.
+
+Typical modifications when moving from notebook to script include:
+    The need to create a renderer with a chosen backend.
+    e.g. renderer = hv.renderer('matplotlib')
+
+    plots are saved using render.save method.
+    e.g. renderer.save(obj, 'my_filename')
+
+    instead of ipython magics for controlling how elements look
+    options are passed using the .opts() methods.
+    below is an ipython cell magic format example
+    %opts Image {+framewise} [colorbar=True] Curve [xrotation=60]
+
+    when applying the above options globally you would do
+    hv.opts("Image {+framewise} [colorbar=True] Curve [xrotation=60]")
+
+    if you want to apply the options just to the object you would do
+    obj.opts("Image {+framewise} [colorbar=True] Curve [xrotation=60]")
+
+    Note that the .opts() method can also take a dictionary as an arg
+    but for ease of use the string format is preferred.
+
+    Here dynamic examples have been included, but the plots will be static
+    like in the docs.
+
+    If you want an example script that you can serve using a boker server
+    See Gridded_Datasets_II_dyn.py
+"""
+
+def realization_plot():
+    """
+    Multi-dimensional datastructure example
+    Produce HoloMap with two sliders
+    """
+
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+    hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    geo_dims = ['longitude', 'latitude']
+    img = (dataset.to(gv.Image, geo_dims) * gf.coastline)[::5, ::5]
+    renderer.save(img, 'realization')
+
+def realization_plot_3panel():
+    """
+    Three panel example with FilledContours, LineContours and Point elements
+    """
+
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+    hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    geo_dims = ['longitude', 'latitude']
+    img = hv.Layout([dataset.to(el, geo_dims)[::10, ::10] * gf.coastline
+                   for el in [gv.FilledContours, gv.LineContours, gv.Points]]).cols(1)
+
+    # apply the opts locally by using them on img rather than hv.opts
+    opts = "Points [color_index=2 size_index=None] (cmap='jet')"
+    renderer.save(img.opts(opts), 'realization_3panel')
+
+def dynamic_example():
+    """
+    requires a bokeh serve command to work correctly, saved html image
+    will be like that on the website, the slider won't work.
+    If you want to have the dynamic feature work
+    See Gridded_Datasets_II_dyn.py and use a bokeh server
+    """
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+    hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    geo_dims = ['longitude', 'latitude']
+    img = (dataset.to(gv.Image, geo_dims, dynamic=True) * gf.coastline)
+    renderer.save(img, 'dynamic_example')
+
+def irregularly_sampled_data():
+    """
+    If you get an issue with dates in the dataset, delete the file in
+    ~/.xarray_tutorial_data/
+
+    from the projection we can tell docs use matplotlib backend.
+    however, to get dynamic=True to work outside of notebook we
+    will use a bokeh server, which means which means we need bokeh backend.
+
+    Here we will just replicate what is in the docs. For a true dynamic
+    example see Gridded_Datasets_II_dyn.
+    """
+
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+
+    # cannot use projections in the img.opts() like in notebook notebook
+    opts = "QuadMesh [colorbar=True fig_size=300] (cmap='RdBu_r')"
+    xrds = xr.tutorial.load_dataset('rasm')
+
+    qmesh = gv.Dataset(xrds.Tair).to(gv.QuadMesh, ['xc', 'yc'], dynamic=True)
+    print('loaded')
+    qmesh.redim.range(Tair=(-30, 30)) * gf.coastline
+
+    # apply the opts, and do the projection
+    img = qmesh.opts(opts)(plot=dict(projection=ccrs.Robinson())) * gf.coastline
+    renderer.save(img, 'irregularly_sampled_data')
+
+def temp_over_time():
+    """
+    Non-geographic views.
+    """
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+    #hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    opts = "Curve [xrotation=25 width=400 height=200] {+framewise} NdOverlay [legend_position='right' toolbar='above']"
+    # apply options globally
+    hv.opts(opts)
+
+    opts_crv = "Curve [xrotation=25 width=400 height=200] {+framewise}"
+    opts_nd = " NdOverlay [legend_position='right' toolbar='above']"
+    img = dataset.to(hv.Curve, 'time', dynamic=True).opts(opts_crv).overlay('realization').opts(opts_nd)
+
+    renderer.save(img, 'temp_over_time')
+
+
+def heatmap():
+    """
+    requires a bokeh serve command to work correctly, saved html image
+    will be like that on the website, the slider won't work.
+    If you want to have the dynamic feature work see
+    Gridded_Datasets_II_dyn.py
+    """
+
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+    #hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    opts = "HeatMap [width=400 colorbar=True tools=['hover'] toolbar='above']"
+    # apply options globally
+    hv.opts(opts)
+    img = dataset.to(hv.HeatMap, ['realization', 'time'], dynamic=True)
+    renderer.save(img, 'dynamic_heatmap')
+
+def boxplots():
+    """
+    lower-dimensional view, boxplot example
+    """
+
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+    #hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    opts = "BoxWhisker [xrotation=25 bgcolor='w']"
+    hv.opts(opts)
+    img = hv.Layout([dataset.to(hv.BoxWhisker, d, None, []) for d in ['time', 'realization']])
+    renderer.save(img, 'box_plots')
+
+def distribution_example():
+    """
+    lower-dimensional view, Distribution example
+    """
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+    #hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    opts = "GridSpace [shared_xaxis=True]"
+    hv.opts(opts)
+    grid = dataset.to(hv.Distribution, 'surface_temperature', groupby=['realization', 'time']).grid()
+    renderer.save(grid, 'distribution')
+
+def slice_example():
+    """
+    Easily select ranges of coordinates
+    """
+
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+    hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    geo_dims = ['longitude', 'latitude']
+    northern = dataset.select(latitude=(25, 75))
+    img = (northern.select(longitude=(260, 305)).to(gv.Image, geo_dims) *
+             northern.select(longitude=(330, 362)).to(gv.Image, geo_dims) *
+              gf.coastline)[::5, ::5]
+    renderer.save(img, 'slice_example')
+
+def select_coords():
+    """
+    Select a coord and cast dta to Curves element
+    """
+
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+    hv.output('size=100')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    geo_dims = ['longitude', 'latitude']
+
+    opts ="NdOverlay [width=600 height=400 legend_position='right' toolbar='above'] Curve (color=Palette('Set1'))"
+    img = dataset.select(latitude=0, longitude=0).to(hv.Curve, ['time']).reindex().overlay()
+
+    renderer.save(img.opts(opts), 'select_coords')
+
+def aggregate_example():
+    """
+    Aggregate over dimensions.
+    Compute mean and standard deviation by latitude and longitude
+    """
+
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+    hv.output('size=100')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    geo_dims = ['longitude', 'latitude']
+
+    img = hv.Spread(dataset.aggregate('latitude', np.mean, np.std)) +\
+                hv.Spread(dataset.aggregate('longitude', np.mean, np.std))
+
+    renderer.save(img, 'aggregate_example')
+
+if __name__ == '__main__':
+    realization_plot()
+    realization_plot_3panel()
+    dynamic_example()
+    irregularly_sampled_data()
+    temp_over_time()
+    heatmap()
+    boxplots()
+    distribution_example()
+    slice_example()
+    select_coords()
+    aggregate_example()
+

--- a/notebooks/user_guide/Gridded_Datasets_II.py
+++ b/notebooks/user_guide/Gridded_Datasets_II.py
@@ -4,7 +4,6 @@ import holoviews as hv
 import geoviews as gv
 import geoviews.feature as gf
 from cartopy import crs as ccrs
-from bokeh.plotting import curdoc, save, output_file
 
 """
 The following examples were taken from

--- a/notebooks/user_guide/Gridded_Datasets_II_dyn.py
+++ b/notebooks/user_guide/Gridded_Datasets_II_dyn.py
@@ -1,0 +1,150 @@
+import numpy as np
+import xarray as xr
+import holoviews as hv
+import geoviews as gv
+import geoviews.feature as gf
+from cartopy import crs as ccrs
+from bokeh.plotting import curdoc, save, output_file
+
+"""
+The following examples were taken from
+http://geoviews.org/user_guide/Gridded_Datasets_II.html
+
+This script is designed to be run used with the bokeh server.
+
+To run it you can do the following
+bokeh serve --allow-websocket-origin localhost:5006  Gridded_Datasets_II_dyn.py'
+then in a browser connect to localhost:5006/Gridded_Datasets_II_dyn
+
+Make sure port 5006 is open in your firewall
+
+For sample non-dynamic script that has all the plots in the docs see 
+Gridded_Datasets_II.py
+"""
+
+def dynamic_example():
+    """
+    requires a bokeh serve command to work correctly
+
+    If you want to have the dynamic feature work use the following
+
+    bokeh serve --allow-websocket-origin localhost:5006  Gridded_Datasets_II_dyn.py'
+
+    then in browser address bar enter
+
+    localhost:5006/Gridded_Datasets_II_dyn
+
+    see bokeh docs or system admin if you cannot get this to work
+    """
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+    hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    geo_dims = ['longitude', 'latitude']
+    img = (dataset.to(gv.Image, geo_dims, dynamic=True) * gf.coastline)
+
+    # to get the dynamic feature to work must create a bokeh doc
+    # and run the script through a bokeh serve
+    doc = renderer.server_doc(img)
+    return doc
+
+def irregularly_sampled_data():
+    """
+    If you get an issue with dates in the dataset, delete the file in
+    ~/.xarray_tutorial_data/
+    from projection we can tell docs use matplotlib backend.
+    however, to get dynamic=True outside of notebook we will need to use
+    the bokeh serve which means we need bokeh backend.
+    """
+
+    hv.extension('bokeh')
+    renderer = hv.renderer('bokeh')
+
+    # cannot use projections in the img.opts() like in notebook notebook
+    opts = "QuadMesh [colorbar=True fig_size=300] (cmap='RdBu_r')"
+    xrds = xr.tutorial.load_dataset('rasm')
+
+    qmesh = gv.Dataset(xrds.Tair).to(gv.QuadMesh, ['xc', 'yc'], dynamic=True)
+    print('loaded')
+    qmesh.redim.range(Tair=(-30, 30)) * gf.coastline
+
+    # apply the opts, and do the projection
+    img = qmesh.opts(opts)(plot=dict(projection=ccrs.Robinson())) * gf.coastline
+
+    # instead of renderer.save use renderer.server_doc so we can display
+    # using a bokeh server
+    doc = renderer.server_doc(img)
+    return doc
+
+def temp_over_time():
+    """
+    Non-geographic views, dynamic example
+    """
+
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+    #hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    opts = "Curve [xrotation=25 width=400 height=200] {+framewise} NdOverlay [legend_position='right' toolbar='above']"
+    # apply options globally
+    hv.opts(opts)
+
+    opts_crv = "Curve [xrotation=25 width=400 height=200] {+framewise}"
+    opts_nd = " NdOverlay [legend_position='right' toolbar='above']"
+    img = dataset.to(hv.Curve, 'time', dynamic=True).opts(opts_crv).overlay('realization').opts(opts_nd)
+
+    # instead of renderer.save use renderer.server_doc so we can display
+    # using a bokeh server
+    doc = renderer.server_doc(img)
+    return doc
+
+def heatmap():
+    """
+    requires a bokeh serve command to work correctly
+
+    If you want to have the dynamic feature work use the following
+
+    bokeh serve --allow-websocket-origin localhost:5006  Gridded_Datasets_II_dyn.py'
+
+    then in browser address bar enter
+
+    localhost:5006/Gridded_Datasets_II_dyn
+
+    see bokeh docs or system admin if you cannot get this to work
+    """
+
+    hv.extension('bokeh', 'matplotlib')
+    renderer = hv.renderer('bokeh')
+    #hv.output('size=200')
+
+    xr_ensembles = xr.open_dataset('./sample-data/ensembles.nc')
+    dataset = gv.Dataset(xr_ensembles, vdims='surface_temperature', crs=ccrs.PlateCarree())
+
+    hv.Dimension.type_formatters[np.datetime64] = '%Y-%m-%d'
+
+    opts = "HeatMap [width=400 colorbar=True tools=['hover'] toolbar='above']"
+    # apply options globally
+    hv.opts(opts)
+    img = dataset.to(hv.HeatMap, ['realization', 'time'], dynamic=True)
+
+    # instead of renderer.save use renderer.server_doc so we can display
+    # using a bokeh server
+    doc = renderer.server_doc(img)
+    return doc
+
+
+doc1 = dynamic_example()
+doc2 = irregularly_sampled_data()
+doc2 = temp_over_time()
+doc3 = heatmap()
+

--- a/notebooks/user_guide/Projections.py
+++ b/notebooks/user_guide/Projections.py
@@ -1,0 +1,69 @@
+import iris
+import numpy as np
+import holoviews as hv
+import geoviews as gv
+import geoviews.feature as gf
+from cartopy import crs
+
+"""
+The following examples were taken from
+http://geo.holoviews.org/user_guide/Projections.html
+
+This script is designed to be run by the python interpreter rather
+than in a notebook.
+Each function has been designed as a stand-alone example.
+
+Typical modifications when moving from notebook to script include:
+    The need to create a renderer with a chosen backend.
+    e.g. renderer = hv.renderer('matplotlib')
+
+    plots are saved using render.save method.
+    e.g. renderer.save(obj, 'my_filename')
+"""
+
+
+def features_plot():
+    """
+    global plot with land, ocean, rivers, lakes, borders and coastline
+    """
+
+    hv.extension('matplotlib')
+    renderer = hv.renderer('matplotlib')
+    renderer.size = 400
+    features = hv.Overlay([gf.land, gf.ocean, gf.rivers, gf.lakes, gf.borders, gf.coastline])
+    renderer.save(features, 'geoviews_features', fmt='png')
+
+
+def matplotlib_projections():
+    """
+    various subplots showing the different projections available in
+    matplotlib backend (bokeh can only do mercator projection).
+    """
+    renderer = hv.renderer('matplotlib')
+    renderer.size = 200
+
+    projections = [crs.RotatedPole, crs.Mercator, crs.LambertCylindrical, crs.Geostationary,
+                   crs.AzimuthalEquidistant, crs.OSGB, crs.EuroPP, crs.Gnomonic, crs.PlateCarree,
+                   crs.Mollweide, crs.OSNI, crs.Miller, crs.InterruptedGoodeHomolosine,
+                   crs.LambertConformal, crs.SouthPolarStereo, crs.AlbersEqualArea, crs.Orthographic,
+                   crs.NorthPolarStereo, crs.Robinson]
+    features = hv.Overlay([gf.land, gf.ocean, gf.rivers, gf.lakes, gf.borders, gf.coastline])
+    img = hv.Layout([gf.coastline.relabel(group=p.__name__)(plot=dict(projection=p()))
+               for p in projections])
+    renderer.save(img, 'matplotlib_projections', fmt='png')
+
+def change_projection():
+    """
+    change projection for a single HoloViews object
+    """
+    renderer = hv.renderer('matplotlib')
+    renderer.size = 200
+    features = hv.Overlay([gf.land, gf.ocean, gf.rivers, gf.lakes, gf.borders, gf.coastline])
+    img = (features.relabel(group='Mollweide')(plot=dict(projection=crs.Mollweide())) +
+            features.relabel(group='Geostationary')(plot=dict(projection=crs.Geostationary())))
+    renderer.save(img, 'change_projection', fmt='png')
+
+if __name__ == '__main__':
+    features_plot()
+    matplotlib_projections()
+    change_projection()

--- a/notebooks/user_guide/Projections.py
+++ b/notebooks/user_guide/Projections.py
@@ -1,7 +1,4 @@
-import iris
-import numpy as np
 import holoviews as hv
-import geoviews as gv
 import geoviews.feature as gf
 from cartopy import crs
 

--- a/notebooks/user_guide/Working_with_Bokeh.py
+++ b/notebooks/user_guide/Working_with_Bokeh.py
@@ -1,0 +1,153 @@
+import xarray as xr
+import numpy as np
+import pandas as pd
+import holoviews as hv
+import geoviews as gv
+import geoviews.feature as gf
+import geopandas as gpd
+
+import cartopy
+from cartopy import crs as ccrs
+
+from bokeh.tile_providers import STAMEN_TONER, STAMEN_TONER_LABELS
+
+"""
+The following examples were taken from
+http://geoviews.org/user_guide/Working_with_Bokeh.html
+
+This script is designed to be run by the python interpreter rather
+than in a notebook.
+
+Typical modifications when moving from notebook to script include:
+    The need to create a renderer with a chosen backend.
+    e.g. renderer = hv.renderer('matplotlib')
+
+    plots are saved using render.save method.
+    e.g. renderer.save(obj, 'my_filename')
+
+    instead of ipython magics for controlling how elements look
+    options are passed using the .opts() methods.
+    below is an ipython cell magic format example
+    %opts Image {+framewise} [colorbar=True] Curve [xrotation=60]
+
+    when applying the above options globally you would do
+    hv.opts("Image {+framewise} [colorbar=True] Curve [xrotation=60]")
+
+    if you want to apply the options just to the object you would do
+    obj.opts("Image {+framewise} [colorbar=True] Curve [xrotation=60]")
+
+    Note that the .opts() method can also take a dictionary as an arg
+    but for ease of use the string format is preferred.
+"""
+
+def WMTS_tiles():
+    """
+    Example showing the different tile sources available.
+    e.g. ESRI, OpenMap, Stamen Toner and Wikipedia
+    """
+
+    hv.extension('bokeh')
+    renderer = hv.renderer('bokeh')
+
+    tiles = {'OpenMap': 'http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png',
+         'ESRI': 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg',
+         'Wikipedia': 'https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png',
+         'Stamen Toner': STAMEN_TONER}
+
+    opts = "WMTS [width=450 height=250 xaxis=None yaxis=None]"
+    img = hv.NdLayout({name: gv.WMTS(wmts).opts(opts)
+                for name, wmts in tiles.items()}, kdims=['Source']).cols(2)
+
+    renderer.save(img, 'WMTS_tiles')
+
+def label_example():
+    """
+    Apply the STAMEN TONER labels to a map
+    """
+
+    hv.extension('bokeh')
+    renderer = hv.renderer('bokeh')
+
+    tiles = {'OpenMap': 'http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png',
+         'ESRI': 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg',
+         'Wikipedia': 'https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png',
+         'Stamen Toner': STAMEN_TONER}
+
+    opts = "WMTS [width=600 height=570]"
+    img = gv.WMTS(tiles['ESRI'], extents=(0, -90, 360, 90), crs=ccrs.PlateCarree()) *\
+            gv.WMTS(STAMEN_TONER_LABELS).opts(style=dict(level='annotation'))
+
+    renderer.save(img.opts(opts), 'label_example')
+
+
+def cities_example():
+    """
+    HoloMap showing city populations over time.
+    Can hover over cities to get information
+
+    """
+    hv.extension('bokeh')
+    renderer = hv.renderer('bokeh')
+
+    tiles = {'OpenMap': 'http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png',
+         'ESRI': 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg',
+         'Wikipedia': 'https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png',
+         'Stamen Toner': STAMEN_TONER}
+
+    cities = pd.read_csv('./assets/cities.csv', encoding="ISO-8859-1")
+    population = gv.Dataset(cities, kdims=['City', 'Country', 'Year'])
+    cities.head()
+
+    opts_ov = "Overlay [width=600 height=350]"
+    opts_pt = " Points (size=0.005 cmap='viridis') [tools=['hover'] size_index=2 color_index=2]"
+    img = (gv.WMTS(tiles['Wikipedia']) *\
+            population.to(gv.Points, kdims=['Longitude', 'Latitude'],
+                              vdims=['Population', 'City', 'Country'], crs=ccrs.PlateCarree()))
+
+    # we can chain opts as well as combing them in the string
+    renderer.save(img.opts(opts_ov).opts(opts_pt), 'cities_example')
+
+
+def choropleth_example():
+    """
+    Example with geopandas.
+    """
+
+    hv.extension('bokeh')
+    renderer = hv.renderer('bokeh')
+
+    geometries = gpd.read_file('./assets/boundaries/boundaries.shp')
+    referendum = pd.read_csv('./assets/referendum.csv')
+    gdf = gpd.GeoDataFrame(pd.merge(geometries, referendum))
+
+    tiles = {'OpenMap': 'http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png',
+         'ESRI': 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg',
+         'Wikipedia': 'https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png',
+         'Stamen Toner': STAMEN_TONER}
+
+    opts = ("Polygons [tools=['hover'] width=450 height=600 color_index=""'leaveVoteshare'"
+            " colorbar=True toolbar='above' xaxis=None yaxis=None]")
+    img = gv.Polygons(gdf, vdims=['name', 'leaveVoteshare'])
+
+    renderer.save(img.opts(opts), 'choropleth_example')
+
+def image_example():
+
+    hv.extension('bokeh')
+    renderer = hv.renderer('bokeh')
+
+    opts = "Overlay [width=600 height=500] Image (cmap='viridis') Feature (line_color='black')"
+    dataset = xr.open_dataset('./sample-data/pre-industrial.nc')
+    air_temperature = gv.Dataset(dataset, kdims=['longitude', 'latitude'], 
+            group='Pre-industrial air temperature', vdims=['air_temperature'], 
+            crs=ccrs.PlateCarree())
+    img = air_temperature.to.image() * gf.coastline()
+
+    renderer.save(img.opts(opts), 'image_example')
+
+if __name__ == '__main__':
+    WMTS_tiles()
+    label_example()
+    cities_example()
+    choropleth_example()
+    image_example()

--- a/notebooks/user_guide/Working_with_Bokeh.py
+++ b/notebooks/user_guide/Working_with_Bokeh.py
@@ -1,12 +1,10 @@
 import xarray as xr
-import numpy as np
 import pandas as pd
 import holoviews as hv
 import geoviews as gv
 import geoviews.feature as gf
 import geopandas as gpd
 
-import cartopy
 from cartopy import crs as ccrs
 
 from bokeh.tile_providers import STAMEN_TONER, STAMEN_TONER_LABELS
@@ -119,11 +117,6 @@ def choropleth_example():
     geometries = gpd.read_file('./assets/boundaries/boundaries.shp')
     referendum = pd.read_csv('./assets/referendum.csv')
     gdf = gpd.GeoDataFrame(pd.merge(geometries, referendum))
-
-    tiles = {'OpenMap': 'http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png',
-         'ESRI': 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg',
-         'Wikipedia': 'https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png',
-         'Stamen Toner': STAMEN_TONER}
 
     opts = ("Polygons [tools=['hover'] width=450 height=600 color_index=""'leaveVoteshare'"
             " colorbar=True toolbar='above' xaxis=None yaxis=None]")


### PR DESCRIPTION
When I first started not having working examples was quite difficult. It's obvious to me now how to get the same results as the ipython magics, but at the time I recall it was quite confusing 

These should be useful for people who don't or can't use the notebooks.

I tried to show a few different ways to set the plot options, i.e. globally, or locally, using dictionary or strings. 

I wasn't 100% sure when to put them, so ended up putting them in the notebooks/user_guide directory.

In the docs there is a link that says "Right click to download this notebook from GitHub."

I would also suggest adding "Right click to download this script from GitHub."
