### PR TITLE
Exposed parts of holoviews API

### DIFF
--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -1,4 +1,7 @@
 import param
+
+from holoviews import extension, help, opts, output, renderer, Store, Cycle, Palette # noqa (API import)
+
 from .element import (_Element, Feature, Tiles,     # noqa (API import)
                       WMTS, LineContours, FilledContours, Text, Image,
                       Points, Path, Polygons, Shape, Dataset, RGB,
@@ -11,16 +14,16 @@ from . import feature                               # noqa (API import)
 
 
 __version__ = str(param.version.Version(fpath=__file__, archive_commit="$Format:%h$",
-                              reponame="geoviews"))
+                                        reponame="geoviews"))
 
 
 # make pyct's example/data commands available if possible
 from functools import partial
 try:
     from pvutil.cmd import copy_examples as _copy, fetch_data as _fetch, examples as _examples
-    copy_examples = partial(_copy,'geoviews')
-    fetch_data = partial(_fetch,'geoviews')
-    examples = partial(_examples,'geoviews')
+    copy_examples = partial(_copy, 'geoviews')
+    fetch_data = partial(_fetch, 'geoviews')
+    examples = partial(_examples, 'geoviews')
 except ImportError:
     def _missing_cmd(*args,**kw): return("install pyct to enable this command (e.g. `conda install pyct`)")
     _copy = _fetch = _examples = _missing_cmd


### PR DESCRIPTION
As discussed in https://github.com/ioam/geoviews/issues/78 this PR exposes parts of the HoloViews API in geoviews. Here is what is exposed:

```
from holoviews import extension, help, opts, output, renderer, Store, Cycle, Palette # noqa (API import)
```

- [x] Addresses https://github.com/ioam/geoviews/issues/42 and https://github.com/ioam/geoviews/issues/78