### PR TITLE
Improved hover formatter and allowed image hover

### DIFF
--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -97,6 +97,14 @@ class GeoRasterPlot(GeoPlot, RasterPlot):
 
     _project_operation = project_image.instance(fast=False)
 
+    _hover_code = """
+        var projections = require("core/util/projections");
+        var x = special_vars.x
+        var y = special_vars.y
+        var coords = projections.wgs84_mercator.inverse([x, y])
+        return "" + (coords[%d]).toFixed(4)
+    """
+
 
 class GeoRGBPlot(GeoPlot, RGBPlot):
 


### PR DESCRIPTION
Improves the hover formatter code to allow formatting images and updated for API change, e.g.:

<img width="1005" alt="screen shot 2018-05-08 at 3 19 20 am" src="https://user-images.githubusercontent.com/1550771/39734292-a2bfa26e-526e-11e8-8474-912ea44e66bb.png">
