### PR TITLE
Make projection configurable in bokeh backend

### DIFF
--- a/examples/Homepage.ipynb
+++ b/examples/Homepage.ipynb
@@ -25,7 +25,7 @@
     "import xarray as xr\n",
     "from cartopy import crs\n",
     "\n",
-    "hv.extension('matplotlib', 'bokeh')"
+    "hv.extension('bokeh', 'matplotlib')"
    ]
   },
   {
@@ -36,7 +36,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Feature [projection=crs.Geostationary()]\n",
+    "%%opts Feature [projection=crs.Geostationary() global_extent=True show_bounds=True]\n",
     "(gf.ocean + gf.land + gf.ocean * gf.land * gf.coastline * gf.borders).cols(3)"
    ]
   },
@@ -57,6 +57,7 @@
    },
    "outputs": [],
    "source": [
+    "%%output backend='matplotlib'\n",
     "dataset = gv.Dataset(xr.open_dataset('./data/ensemble.nc'))\n",
     "dataset.to(gv.Image, ['longitude', 'latitude']).options(cmap='viridis', colorbar=True, fig_size=200) * gf.coastline()"
    ]
@@ -74,7 +75,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%output backend='bokeh'\n",
     "import geopandas as gpd\n",
     "gv.Polygons(gpd.read_file(gpd.datasets.get_path('naturalearth_lowres')), vdims='pop_est').options(\n",
     "    tools=['hover'], height=500, width=500\n",

--- a/examples/Homepage.ipynb
+++ b/examples/Homepage.ipynb
@@ -36,7 +36,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Feature [projection=crs.Geostationary() global_extent=True show_bounds=True]\n",
+    "%%opts Feature [projection=crs.Geostationary() global_extent=True show_bounds=True height=325]\n",
     "(gf.ocean + gf.land + gf.ocean * gf.land * gf.coastline * gf.borders).cols(3)"
    ]
   },

--- a/examples/gallery/matplotlib/orthographic_vectorfield.ipynb
+++ b/examples/gallery/matplotlib/orthographic_vectorfield.ipynb
@@ -67,9 +67,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "opts = {'plot': dict(size_index='Magnitude', show_grid=True,\n",
-    "                     projection=ccrs.Orthographic(-10, 45))}\n",
-    "(gf.ocean * gf.coastline * gf.land * vectorfield.opts(**opts)).redim.range(Longitude=(-180, 180), Latitude=(-90, 90))"
+    "opts = dict(size_index='Magnitude', show_grid=True, projection=ccrs.Orthographic(-10, 45))\n",
+    "(gf.ocean * gf.coastline * gf.land * vectorfield.options(**opts)).redim.range(Longitude=(-180, 180), Latitude=(-90, 90))"
    ]
   }
  ],

--- a/examples/user_guide/Projections.ipynb
+++ b/examples/user_guide/Projections.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "The GeoViews package provides a library of [HoloViews](https://holoviews.org) Element types which make it very easy to plot data on various geographic projections and other utilities to plot in geographic coordinate systems. Elements are very simple wrappers around the data the only thing that distinguishes a GeoViews element from a HoloViews one is the addition of a ``crs`` parameter, which defines a cartopy coordinate reference system declaring the coordinate system of the data. This allows GeoViews to automatically project the data. By default all elements assume a ``PlateCarree`` projection (also sometimes known as the equirectangular projection), which lets you define the data in longitudes and latitudes.\n",
     "\n",
-    "By default the plot will follow the specified ``crs`` when using matplotlib and automatically project data to Web mercator when plotting with bokeh."
+    "By default the plot will follow the ``crs`` declared on the elements when using matplotlib:"
    ]
   },
   {
@@ -37,6 +37,23 @@
     "features = hv.Overlay([gf.ocean, gf.land, gf.rivers, gf.lakes, gf.borders, gf.coastline])\n",
     "print(gf.land.crs)\n",
     "features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When plotting with bokeh on the other hand it will default to Web mercator since that is the only projection which supports tile sources:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%output backend='bokeh'\n",
+    "features.options(width=500, height=500, global_extent=True)"
    ]
   },
   {
@@ -64,8 +81,8 @@
     "projections = [crs.RotatedPole, crs.Mercator, crs.LambertCylindrical, crs.Geostationary, \n",
     "               crs.AzimuthalEquidistant, crs.OSGB, crs.EuroPP, crs.Gnomonic, crs.PlateCarree, \n",
     "               crs.Mollweide, crs.OSNI, crs.Miller, crs.InterruptedGoodeHomolosine,\n",
-    "               crs.LambertConformal, crs.SouthPolarStereo, crs.AlbersEqualArea, crs.Orthographic,\n",
-    "               crs.NorthPolarStereo, crs.Robinson]"
+    "               crs.SouthPolarStereo,  crs.Orthographic, crs.NorthPolarStereo, crs.Robinson,\n",
+    "               crs.LambertConformal, crs.AlbersEqualArea]"
    ]
   },
   {
@@ -98,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note however that only the matplotlib backend supports plotting the data in different projections. When using the bokeh plotting extension all data will be projected to Web Mercator coordinates since that is the native coordinate system for interactive tile sources."
+    "The bokeh backend supports almost all the same projections except for ``LambertConformal`` and ``AlbersEqualArea``. The bokeh backend will however not automatically handle drawing drawing of the bounds and disabling of the axes so these options need to be set manually:"
    ]
   },
   {
@@ -107,8 +124,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%output backend='bokeh' size=200\n",
-    "features"
+    "%%output backend='bokeh'\n",
+    "opts = dict(show_bounds=True, width=200, height=225, global_extent=True, axiswise=True, xaxis=None, yaxis=None)\n",
+    "hv.Layout([gf.coastline.relabel(group=p.__name__).options(projection=p(), **opts) for p in projections[:-2]]).cols(5)"
    ]
   },
   {

--- a/examples/user_guide/Working_with_Bokeh.ipynb
+++ b/examples/user_guide/Working_with_Bokeh.ipynb
@@ -23,16 +23,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In most GeoViews examples, we have selected the matplotlib plotting backend, because it has general support for projecting data to different geographic projections using cartopy. The Bokeh backend offers much more advanced tools to interactively explore data, but is currently restricted to displaying data in web Mercator coordinates, something GeoViews will handle automatically as long as you declare the appropriate coordinate reference system on your data.\n",
-    "\n",
-    "One of the most useful features Bokeh provides, is support for renderering your data on top of web-based map tile sources."
+    "The Bokeh backend offers much more advanced tools to interactively explore data, especially due to the support for web mapping tile sources. As we learned in the [Projections](Projections.ipynb) user guide using web mapping tile sources is only supported when using the default ``GOOGLE_MERCATOR`` ``crs``."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# WMTS Tile Sources"
+    "# WMTS - Tile Sources"
    ]
   },
   {

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -4,7 +4,7 @@ from cartopy import crs as ccrs
 from cartopy.feature import Feature as cFeature
 from cartopy.io.img_tiles import GoogleTiles
 from cartopy.io.shapereader import Reader
-from holoviews.core import Element2D, Dimension, Dataset as HvDataset, NdOverlay
+from holoviews.core import Element2D, Dimension, Dataset as HvDataset, NdOverlay, Overlay
 from holoviews.core.util import (basestring, pd, max_extents,
                                  dimension_range, get_param_values)
 from holoviews.element import (
@@ -42,8 +42,8 @@ def is_geographic(element, kdims=None):
     a subset of its key dimensions represent a geographic coordinate
     system.
     """
-    if isinstance(element, NdOverlay):
-        element = element.last
+    if isinstance(element, (Overlay, NdOverlay)):
+        return any(element.traverse(is_geographic, [_Element]))
 
     if kdims:
         kdims = [element.get_dimension(d) for d in kdims]

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -96,6 +96,8 @@ class project_shape(_project_operation):
         if not len(element):
             return element.clone(crs=self.p.projection)
         geom = self.p.projection.project_geometry(element.geom(), element.crs)
+        if isinstance(geom, tuple):
+            geom = [g for g in geom if g != []][0]
         return element.clone(geom, crs=self.p.projection)
 
 

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -217,7 +217,7 @@ class FeaturePlot(GeoPolygonPlot):
             self._plot_methods = dict(single='patches', batched='patches')
         geoms = [self.projection.project_geometry(geom, element.crs)
                  for geom in geoms]
-        xs, ys = zip(*(geom_to_array(geom).T for geom in geoms))
+        xs, ys = zip(*(geom_to_array(geom).T for geom in geoms if geom != []))
         data = dict(xs=list(xs), ys=list(ys))
         return data, mapping, style
 

--- a/geoviews/plotting/bokeh/callbacks.py
+++ b/geoviews/plotting/bokeh/callbacks.py
@@ -11,7 +11,7 @@ from holoviews.streams import (Stream, PointerXY, RangeXY, RangeX, RangeY,
                                MouseLeave, Bounds, BoundsXY)
 
 from ...util import project_extents
-from .plot import DEFAULT_PROJ, OverlayPlot
+from .plot import OverlayPlot
 
 
 def get_cb_plot(cb, plot=None):
@@ -50,7 +50,7 @@ def project_ranges(cb, msg, attributes):
     x0, x1 = msg.get('x_range', (0, 1000))
     y0, y1 = msg.get('y_range', (0, 1000))
     extents = x0, y0, x1, y1
-    x0, y0, x1, y1 = project_extents(extents, DEFAULT_PROJ,
+    x0, y0, x1, y1 = project_extents(extents, plot.projection,
                                      plot.current_frame.crs)
     coords = {'x_range': (x0, x1), 'y_range': (y0, y1)}
     return {k: v for k, v in coords.items() if k in attributes}
@@ -64,7 +64,7 @@ def project_point(cb, msg, attributes=('x', 'y')):
     plot = get_cb_plot(cb)
     x, y = msg.get('x', 0), msg.get('y', 0)
     crs = plot.current_frame.crs
-    coordinates = crs.transform_points(DEFAULT_PROJ, np.array([x]), np.array([y]))
+    coordinates = crs.transform_points(plot.projection, np.array([x]), np.array([y]))
     msg['x'], msg['y'] = coordinates[0, :2]
     return {k: v for k, v in msg.items() if k in attributes}
 
@@ -95,7 +95,7 @@ class GeoBoundsXYCallback(BoundsCallback):
         msg = super(GeoBoundsXYCallback, self)._process_msg(msg)
         if skip(self, msg, ('bounds',)): return msg
         plot = get_cb_plot(self)
-        msg['bounds'] = project_extents(msg['bounds'], DEFAULT_PROJ,
+        msg['bounds'] = project_extents(msg['bounds'], plot.projection,
                                         plot.current_frame.crs)
         return msg
 
@@ -107,7 +107,7 @@ class GeoBoundsXCallback(BoundsXCallback):
         if skip(self, msg, ('boundsx',)): return msg
         x0, x1 = msg['boundsx']
         plot = get_cb_plot(self)
-        x0, _, x1, _ = project_extents((x0, 0, x1, 0), DEFAULT_PROJ,
+        x0, _, x1, _ = project_extents((x0, 0, x1, 0), plot.projection,
                                         plot.current_frame.crs)
         return {'boundsx': (x0, x1)}
 
@@ -119,7 +119,7 @@ class GeoBoundsYCallback(BoundsYCallback):
         if skip(self, msg, ('boundsy',)): return msg
         y0, y1 = msg['boundsy']
         plot = get_cb_plot(self)
-        _, y0, _, y1 = project_extents((0, y0, 0, y1), DEFAULT_PROJ,
+        _, y0, _, y1 = project_extents((0, y0, 0, y1), plot.projection,
                                         plot.current_frame.crs)
         return {'boundsy': (y0, y1)}
 

--- a/geoviews/plotting/bokeh/callbacks.py
+++ b/geoviews/plotting/bokeh/callbacks.py
@@ -11,7 +11,7 @@ from holoviews.streams import (Stream, PointerXY, RangeXY, RangeX, RangeY,
                                MouseLeave, Bounds, BoundsXY)
 
 from ...util import project_extents
-from .plot import OverlayPlot
+from .plot import GeoOverlayPlot
 
 
 def get_cb_plot(cb, plot=None):
@@ -19,7 +19,7 @@ def get_cb_plot(cb, plot=None):
     Finds the subplot with the corresponding stream.
     """
     plot = plot or cb.plot
-    if isinstance(plot, OverlayPlot):
+    if isinstance(plot, GeoOverlayPlot):
         plots = [get_cb_plot(cb, p) for p in plot.subplots.values()]
         plots = [p for p in plots if any(s in cb.streams and getattr(s, '_triggering', False)
                                          for s in p.streams)]

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -28,7 +28,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
                                         BoxZoomTool(match_aspect=True), 'reset'],
         doc="A list of plugin tools to use on the plot.")
 
-    is_global = param.Boolean(default=False, doc="""
+    global_extent = param.Boolean(default=False, doc="""
         Whether the plot should display the whole globe.""")
 
     show_grid = param.Boolean(default=False, doc="""
@@ -106,7 +106,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
         """
 
         proj = self.projection
-        if self.is_global:
+        if self.global_extent:
             (x0, x1), (y0, y1) = proj.x_limits, proj.y_limits
             return (x0, y0, x1, y1)
         extents = super(GeoPlot, self).get_extents(element, ranges)
@@ -135,7 +135,7 @@ class OverlayPlot(GeoPlot, HvOverlayPlot):
     for geographic plots.
     """
 
-    _propagate_options = HvOverlayPlot._propagate_options + ['is_global']
+    _propagate_options = HvOverlayPlot._propagate_options + ['global_extent']
 
     def __init__(self, element, **params):
         super(OverlayPlot, self).__init__(element, **params)

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -1,9 +1,11 @@
 """
 Module for geographic bokeh plot baseclasses.
 """
+from distutils.version import LooseVersion
 
 import param
 import numpy as np
+import holoviews as hv
 
 from cartopy.crs import GOOGLE_MERCATOR, PlateCarree, Mercator
 from bokeh.models.tools import BoxZoomTool, WheelZoomTool
@@ -163,3 +165,8 @@ class GeoOverlayPlot(GeoPlot, HvOverlayPlot):
         self.geographic = any(element.traverse(is_geographic, [_Element]))
         if self.geographic:
             self.show_grid = False
+        if LooseVersion(hv.__version__) < '1.10.4':
+            projection = self._get_projection(element)
+            self.projection = projection
+            for p in self.subplots.values():
+                p.projection = projection

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -14,9 +14,10 @@ from holoviews.core.util import dimension_sanitizer, basestring
 
 from ...element import is_geographic, _Element
 from ...util import project_extents
+from ..plot import ProjectionPlot
 
 
-class GeoPlot(ElementPlot):
+class GeoPlot(ProjectionPlot, ElementPlot):
     """
     Plotting baseclass for geographic plots with a cartopy projection.
     """

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -10,8 +10,7 @@ try:
 except:
     WebMapTileService = None
 
-from holoviews.core import (Store, HoloMap, Layout, Overlay,
-                            CompositeOverlay, Element, NdLayout)
+from holoviews.core import Store, HoloMap, Layout, Overlay, Element, NdLayout
 from holoviews.core import util
 from holoviews.core.data import GridInterface
 from holoviews.core.options import SkipRendering, Options
@@ -32,50 +31,10 @@ from ...element import (Image, Points, Feature, WMTS, Tiles, Text,
                         EdgePaths, Graph, TriMesh, QuadMesh, VectorField,
                         HexTiles, Labels)
 from ...util import project_extents, geo_mesh
+from ..plot import ProjectionPlot
 
 from ...operation import project_points, project_path, project_graph, project_quadmesh
 
-
-def _get_projection(el):
-    """
-    Get coordinate reference system from non-auxiliary elements.
-    Return value is a tuple of a precedence integer and the projection,
-    to allow non-auxiliary components to take precedence.
-    """
-    result = None
-    if hasattr(el, 'crs'):
-        result = (int(el._auxiliary_component), el.crs)
-    return result
-
-
-class ProjectionPlot(object):
-    """
-    Implements custom _get_projection method to make the coordinate
-    reference system available to HoloViews plots as a projection.
-    """
-
-    def _get_projection(cls, obj):
-        # Look up custom projection in options
-        isoverlay = lambda x: isinstance(x, CompositeOverlay)
-        opts = cls._traverse_options(obj, 'plot', ['projection'],
-                                     [CompositeOverlay, Element],
-                                     keyfn=isoverlay, defaults=False)
-        from_overlay = not all(p is None for p in opts[True]['projection'])
-        projections = opts[from_overlay]['projection']
-        custom_projs = [p for p in projections if p is not None]
-        if len(set([type(p) for p in custom_projs])) > 1:
-            raise Exception("An axis may only be assigned one projection type")
-        elif custom_projs:
-            return custom_projs[0]
-
-        # If no custom projection is supplied traverse object to get
-        # the custom projections and sort by precedence
-        projections = sorted([p for p in obj.traverse(_get_projection, [Element])
-                              if p is not None and p[1] is not None])
-        if projections:
-            return projections[0][1]
-        else:
-            return None
 
 
 class LayoutPlot(ProjectionPlot, HvLayoutPlot):

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -57,10 +57,10 @@ class GeoOverlayPlot(ProjectionPlot, HvOverlayPlot):
     the correct projection for each axis.
     """
 
-    is_global = param.Boolean(default=False, doc="""
-        Whether the plot should display the whole globe.""")
+    global_extent = param.Boolean(default=False, doc="""
+        Set the extent of the Axes to the limits of the projection.""")
 
-    _propagate_options = HvOverlayPlot._propagate_options + ['is_global']
+    _propagate_options = HvOverlayPlot._propagate_options + ['global_extent']
 
     def __init__(self, element, **params):
         super(GeoOverlayPlot, self).__init__(element, **params)
@@ -74,7 +74,7 @@ class GeoOverlayPlot(ProjectionPlot, HvOverlayPlot):
         axis = self.handles['axis']
         if self.show_grid:
             axis.gridlines()
-        if self.is_global:
+        if self.global_extent:
             axis.set_global()
         return ret
 
@@ -88,7 +88,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
     apply_ranges = param.Boolean(default=False, doc="""
         Do not use ranges to compute plot extents by default.""")
 
-    is_global = param.Boolean(default=False, doc="""
+    global_extent = param.Boolean(default=False, doc="""
         Whether the plot should display the whole globe.""")
 
     projection = param.Parameter(default=ccrs.PlateCarree())
@@ -145,7 +145,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
         axis = self.handles['axis']
         if self.show_grid:
             axis.gridlines()
-        if self.is_global:
+        if self.global_extent:
             axis.set_global()
         return ret
 

--- a/geoviews/plotting/plot.py
+++ b/geoviews/plotting/plot.py
@@ -1,0 +1,43 @@
+from holoviews.core import CompositeOverlay, Element
+
+
+def _get_projection(el):
+    """
+    Get coordinate reference system from non-auxiliary elements.
+    Return value is a tuple of a precedence integer and the projection,
+    to allow non-auxiliary components to take precedence.
+    """
+    result = None
+    if hasattr(el, 'crs'):
+        result = (int(el._auxiliary_component), el.crs)
+    return result
+
+
+class ProjectionPlot(object):
+    """
+    Implements custom _get_projection method to make the coordinate
+    reference system available to HoloViews plots as a projection.
+    """
+
+    def _get_projection(cls, obj):
+        # Look up custom projection in options
+        isoverlay = lambda x: isinstance(x, CompositeOverlay)
+        opts = cls._traverse_options(obj, 'plot', ['projection'],
+                                     [CompositeOverlay, Element],
+                                     keyfn=isoverlay, defaults=False)
+        from_overlay = not all(p is None for p in opts[True]['projection'])
+        projections = opts[from_overlay]['projection']
+        custom_projs = [p for p in projections if p is not None]
+        if len(set([type(p) for p in custom_projs])) > 1:
+            raise Exception("An axis may only be assigned one projection type")
+        elif custom_projs:
+            return custom_projs[0]
+
+        # If no custom projection is supplied traverse object to get
+        # the custom projections and sort by precedence
+        projections = sorted([p for p in obj.traverse(_get_projection, [Element])
+                              if p is not None and p[1] is not None])
+        if projections:
+            return projections[0][1]
+        else:
+            return None

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -117,6 +117,8 @@ def polygon_to_geom(poly, multi=True):
 
 def geom_to_arr(geom):
     arr = geom.array_interface_base['data']
+    if (len(arr) % 2) != 0:
+        arr = arr[:-1]
     return np.array(arr).reshape(int(len(arr)/2), 2)
 
 
@@ -124,7 +126,7 @@ def geom_to_array(geom):
     if hasattr(geom, 'exterior'):
         xs = np.array(geom.exterior.coords.xy[0])
         ys = np.array(geom.exterior.coords.xy[1])
-    elif geom.geom_type == 'LineString':
+    elif geom.geom_type in ('LineString', 'LinearRing'):
         arr = geom_to_arr(geom)
         xs, ys = arr[:, 0], arr[:, 1]
     else:


### PR DESCRIPTION
This makes it possible to change the display projection in bokeh. It will continue defaulting to Web Mercator but if no tile source is required the data may also be projected to any other flat coordinate system such as PlateCarree. This should also make it possible to override the ``central_longitude`` when using the ``is_global`` option.