### PR TITLE
Fixed project operation and added to geoviews namespace

### DIFF
--- a/examples/user_guide/Projections.ipynb
+++ b/examples/user_guide/Projections.ipynb
@@ -163,7 +163,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we have discovered the plotting system will project data to the desired coordinate system automatically. However in certain cases this can be quite expensive especially if it occurs multiple times. Therefore GeoViews makes a high-level operation available to project most types of data from their native ``crs`` to the declared projection. Here we will declare a ``Points`` element containing the longitude/latitude locations of a number of cities. Using the ``gv.operation.project`` operation we can easily project the data to Mercator coordinates:"
+    "As we have discovered the plotting system will project data to the desired coordinate system automatically. However in certain cases this can be quite expensive especially if it occurs multiple times. Therefore GeoViews makes a high-level operation available to project most types of data from their native ``crs`` to the declared projection. Here we will declare a ``Points`` element containing the longitude/latitude locations of a number of cities. Using the ``gv.project`` operation we can easily project the data to Mercator coordinates:"
    ]
   },
   {
@@ -173,7 +173,7 @@
    "outputs": [],
    "source": [
     "cities = gv.Points([(-74.01, 40.71, 'New York'), (0.13, 51.51, 'London'), (116.40, 39.9, 'Beijing')], vdims='City')\n",
-    "projected = gv.operation.project(cities, projection=crs.GOOGLE_MERCATOR)\n",
+    "projected = gv.project(cities, projection=crs.GOOGLE_MERCATOR)\n",
     "print(projected.crs)\n",
     "projected.dframe()"
    ]

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -9,6 +9,7 @@ from .element import (_Element, Feature, Tiles,     # noqa (API import)
                       Points, Path, Polygons, Shape, Dataset, RGB,
                       Contours, Graph, TriMesh, Nodes, EdgePaths,
                       QuadMesh, VectorField, HexTiles, Labels)
+from .operation import project                      # noqa (API import)
 from . import data                                  # noqa (API import)
 from . import operation                             # noqa (API import)
 from . import plotting                              # noqa (API import)

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -312,9 +312,15 @@ class project(Operation):
         Projection the image type is projected to.""")
 
     def _process(self, element, key=None):
-        element = element.map(project_path, project_path.supported_types)
-        element = element.map(project_image, project_image.supported_types)
-        element = element.map(project_shape, project_shape.supported_types)
-        element = element.map(project_graph, project_graph.supported_types)
-        element = element.map(project_quadmesh, project_quadmesh.supported_types)
-        return element.map(project_points, project_points.supported_types)
+        element = element.map(project_path.instance(projection=self.p.projection),
+                              project_path.supported_types)
+        element = element.map(project_image.instance(projection=self.p.projection),
+                              project_image.supported_types)
+        element = element.map(project_shape.instance(projection=self.p.projection),
+                              project_shape.supported_types)
+        element = element.map(project_graph.instance(projection=self.p.projection),
+                              project_graph.supported_types)
+        element = element.map(project_quadmesh.instance(projection=self.p.projection),
+                              project_quadmesh.supported_types)
+        return element.map(project_points.instance(projection=self.p.projection),
+                           project_points.supported_types)


### PR DESCRIPTION
Fixes the ``project`` operation, actually passing the projection through and exposes it in the top-level namespace.