### PR TITLE
Added additional Esri tile sources

### DIFF
--- a/examples/gallery/bokeh/tile_sources.ipynb
+++ b/examples/gallery/bokeh/tile_sources.ipynb
@@ -25,8 +25,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts WMTS [width=400 height=400 xaxis=None yaxis=None] (level='annotation')\n",
-    "(gvts.OSM + gvts.ESRI + gvts.Wikipedia + gvts.StamenToner).cols(2)"
+    "%%opts WMTS [width=200 height=200 xaxis=None yaxis=None] (level='annotation')\n",
+    "(gvts.OSM + gvts.Wikipedia + gvts.StamenToner + gvts.EsriNatGeo +\n",
+    " gvts.EsriImagery + gvts.EsriUSATopo + gvts.EsriTerrain + gvts.EsriReference).cols(4)"
    ]
   }
  ],

--- a/geoviews/tile_sources.py
+++ b/geoviews/tile_sources.py
@@ -6,11 +6,11 @@ _ATTRIBUTIONS = {
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     ),
     ('cartodb',) : (
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, '
         '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
     ),
     ('cartocdn',) : (
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, '
         '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
     ),
     ('stamen', 'terrain') : (
@@ -29,23 +29,23 @@ _ATTRIBUTIONS = {
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     ),
     ('arcgis','Terrain') : (
-        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>, '
         'USGS, NOAA'
     ),
     ('arcgis','Reference') : (
-        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>, '
         'Garmin, USGS, NPS'
     ),
     ('arcgis','Imagery') : (
-        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>, '
         'Earthstar Geographics'
     ),
     ('arcgis','NatGeo') : (
-        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>, '
         'NatGeo, Garmin, HERE, UNEP-WCMC, USGS, NASA, ESA, METI, NRCAN, GEBCO, NOAA, increment P Corp.'
     ),
     ('arcgis','USA_Topo') : (
-        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>, '
         'NatGeo, i-cubed'
     )
 }

--- a/geoviews/tile_sources.py
+++ b/geoviews/tile_sources.py
@@ -30,15 +30,15 @@ _ATTRIBUTIONS = {
     ),
     ('arcgis','Terrain') : (
         '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
-        'HERE, Garmin, FAO, NOAA'
+        'USGS, NOAA'
     ),
     ('arcgis','Reference') : (
         '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
-        'HERE, Garmin, FAO, NOAA'
+        'Garmin, USGS, NPS'
     ),
     ('arcgis','Imagery') : (
         '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
-        'HERE, Garmin, FAO, NOAA | Earthstar Geographics'
+        'Earthstar Geographics'
     ),
     ('arcgis','NatGeo') : (
         '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'

--- a/geoviews/tile_sources.py
+++ b/geoviews/tile_sources.py
@@ -5,11 +5,11 @@ _ATTRIBUTIONS = {
     ('openstreetmap',) : (
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     ),
-    ('cartodb') : (
+    ('cartodb',) : (
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
         '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
     ),
-    ('cartocdn') : (
+    ('cartocdn',) : (
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,'
         '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
     ),
@@ -27,6 +27,26 @@ _ATTRIBUTIONS = {
     ),
     ('wikimedia',) : (
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    ),
+    ('arcgis','Terrain') : (
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        'HERE, Garmin, FAO, NOAA'
+    ),
+    ('arcgis','Reference') : (
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        'HERE, Garmin, FAO, NOAA'
+    ),
+    ('arcgis','Imagery') : (
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        'HERE, Garmin, FAO, NOAA | Earthstar Geographics'
+    ),
+    ('arcgis','NatGeo') : (
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        'NatGeo, Garmin, HERE, UNEP-WCMC, USGS, NASA, ESA, METI, NRCAN, GEBCO, NOAA, increment P Corp.'
+    ),
+    ('arcgis','USA_Topo') : (
+        '&copy; <a href="http://downloads.esri.com/ArcGISOnline/docs/tou_summary.pdf">Esri</a>,'
+        'NatGeo, i-cubed'
     )
 }
 
@@ -44,9 +64,18 @@ StamenToner = WMTS('http://tile.stamen.com/toner/{Z}/{X}/{Y}.png')
 StamenTonerBackground = WMTS('http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png')
 StamenLabels = WMTS('http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png')
 
+# Esri maps (see https://server.arcgisonline.com/arcgis/rest/services for the full list)
+EsriImagery = WMTS('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg')
+EsriNatGeo = WMTS('https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{Z}/{Y}/{X}')
+EsriUSATopo = WMTS('https://server.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{Z}/{Y}/{X}')
+EsriTerrain = WMTS('https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{Z}/{Y}/{X}')
+EsriReference = WMTS('http://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Reference_Overlay/MapServer/tile/{Z}/{Y}/{X}')
+ESRI = EsriImagery # For backwards compatibility with gv 1.5
+
+
 # Miscellaneous
 OSM = WMTS('http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png')
-ESRI = WMTS('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg')
 Wikipedia = WMTS('https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png')
+
 
 tile_sources = {k: v for k, v in locals().items() if isinstance(v, WMTS)}


### PR DESCRIPTION
There are several Esri tile sources that are useful in addition to those included, and this PR adds them with the attributions as listed on the ArcGIS websites:

- [World_Imagery](https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer?f=jsapi)
- [USA_Topo_Maps](https://server.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer?f=jsapi)
- [World_Terrain_Base](https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer?f=jsapi)
- [Reference](https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Reference_Overlay/MapServer?f=jsapi)
- [NatGeo_World_Map](https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer?f=jsapi)

This PR also fixes broken attributions caused by malformed tuples for cartodb and cartocdn.  Finally, it renames ESRI to EsriImagery, to reflect that there are many Esri map servers, though the original name is preserved for compatibility with the 1.5 gv release.