### PR TITLE
Fixed projecting of rectilinear QuadMesh

### DIFF
--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -185,6 +185,10 @@ class project_quadmesh(_project_operation):
                 zs[mask] = np.NaN
 
         params = get_param_values(element)
+        if PX.ndim < 2:
+            PX = PX.reshape(zs.shape)
+        if PY.ndim < 2:
+            PY = PY.reshape(zs.shape)
         return QuadMesh((PX, PY, zs), crs=self.projection, **params)
 
 


### PR DESCRIPTION
Ensures that projected coordinates for a rectilinear mesh are reshaped appropriately.