### PR TITLE
Fix examples command when used from within python

### DIFF
--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -23,13 +23,13 @@ __version__ = str(param.version.Version(fpath=__file__, archive_commit="$Format:
 # make pyct's example/data commands available if possible
 from functools import partial
 try:
-    from pvutil.cmd import copy_examples as _copy, fetch_data as _fetch, examples as _examples
+    from pyct.cmd import copy_examples as _copy, fetch_data as _fetch, examples as _examples
     copy_examples = partial(_copy, 'geoviews')
     fetch_data = partial(_fetch, 'geoviews')
     examples = partial(_examples, 'geoviews')
 except ImportError:
-    def _missing_cmd(*args,**kw): return("install pyct to enable this command (e.g. `conda install pyct`)")
+    def _missing_cmd(*args,**kw): return("install pyct to enable this command (e.g. `conda install -c pyviz pyct`)")
     _copy = _fetch = _examples = _missing_cmd
-    def err(): raise ValueError(_missing_cmd())
-    fetch_data = copy_examples = examples = err
+    def _err(): raise ValueError(_missing_cmd())
+    fetch_data = copy_examples = examples = _err
 del partial, _examples, _copy, _fetch


### PR DESCRIPTION
Currently, doing `python -c "import geoviews; geoviews.examples(...)"` will do nothing except tell you to install pyct, even if you have pyct installed. I somehow missed renaming an import when a package changed name. Sorry about that.

The `geoviews examples` (and related) console scripts do currently work; they aren't affected by this.
