### PR TITLE
Added back some direct dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ stages:
     if: tag =~ ^v(\d+|\.)*[^a-z]\d*$    
   - name: docs
     if: tag =~ ^v(\d+|\.).*$
-  # TODO: add release packages (future PR)
 
 jobs:
   include:

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,9 @@ def package_assets(example_path):
 _required = [
     'bokeh >=0.12.13',   # not strictly required but shouldn't be problematic
     'cartopy >=0.14.2',  # prevents pip alone (requires external package manager)
-    'holoviews >=1.10.1'
+    'holoviews >=1.10.1',
+    'numpy >=1.0',
+    'param >=1.6.1'
 ]
 
 _recommended = [


### PR DESCRIPTION
When I cleaned up the dependencies, I removed some dependencies that are direct dependencies of geoviews. I'm not sure why I did that. I think the direct dependencies should all be listed. What do you think?

This PR shouldn't make any practical difference anywhere (numpy and param being dependencies of hv).
