### PR TITLE
Tiling updates

### DIFF
--- a/examples/gallery/bokeh/xarray_quadmesh.ipynb
+++ b/examples/gallery/bokeh/xarray_quadmesh.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tiles = gv.tile_sources.ESRI\n",
+    "tiles = gv.tile_sources.EsriImagery\n",
     "rasm = xr.tutorial.load_dataset('rasm')\n",
     "qmeshes = gv.Dataset(rasm.Tair[::4, ::3, ::3]).to(gv.QuadMesh, groupby='time')"
    ]

--- a/examples/gallery/matplotlib/tile_sources.ipynb
+++ b/examples/gallery/matplotlib/tile_sources.ipynb
@@ -26,7 +26,8 @@
    "outputs": [],
    "source": [
     "%%opts WMTS [zoom=0] Layout [sublabel_format='' vspace=0.1 hspace=0.1 fig_size=200]\n",
-    "(gvts.OSM + gvts.ESRI + gvts.Wikipedia + gvts.StamenToner).cols(2)"
+    "(gvts.OSM + gvts.Wikipedia + gvts.StamenToner + gvts.EsriNatGeo +\n",
+    " gvts.EsriImagery + gvts.EsriUSATopo + gvts.EsriTerrain + gvts.EsriReference).cols(4)"
    ]
   }
  ],

--- a/examples/gallery/matplotlib/xarray_quadmesh.ipynb
+++ b/examples/gallery/matplotlib/xarray_quadmesh.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tiles = gv.tile_sources.ESRI\n",
+    "tiles = gv.tile_sources.EsriImagery\n",
     "rasm = xr.tutorial.load_dataset('rasm')\n",
     "qmeshes = gv.Dataset(rasm.Tair[::4, ::3, ::3]).to(gv.QuadMesh, groupby='time')"
    ]

--- a/examples/user_guide/Working_with_Bokeh.ipynb
+++ b/examples/user_guide/Working_with_Bokeh.ipynb
@@ -20,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Bokeh backend offers much more advanced tools to interactively explore data, especially due to the support for web mapping tile sources. As we learned in the [Projections](Projections.ipynb) user guide using web mapping tile sources is only supported when using the default ``GOOGLE_MERCATOR`` ``crs``."
+    "The Bokeh backend offers much more advanced tools to interactively explore data, making good use of GeoViews support for web mapping tile sources. As we learned in the [Projections](Projections.ipynb) user guide, using web mapping tile sources is only supported when using the default ``GOOGLE_MERCATOR`` ``crs``."
    ]
   },
   {
@@ -34,7 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "GeoViews provides a number of tile sources by default, provided by CartoDB, Stamen, OpenStreetMap, ESRI and Wikipedia. These can be imported from the ``geoviews.tile_sources`` module."
+    "GeoViews provides a number of tile sources by default, provided by CartoDB, Stamen, OpenStreetMap, Esri and Wikipedia. These can be imported from the ``geoviews.tile_sources`` module."
    ]
   },
   {
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gts.ESRI.options(width=600, height=570, global_extent=True) * gts.StamenLabels.options(level='annotation')"
+    "gts.EsriImagery.options(width=600, height=570, global_extent=True) * gts.StamenLabels.options(level='annotation')"
    ]
   },
   {

--- a/geoviews/tile_sources.py
+++ b/geoviews/tile_sources.py
@@ -13,17 +13,17 @@ _ATTRIBUTIONS = {
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, '
         '&copy; <a href="https://cartodb.com/attributions">CartoDB</a>'
     ),
-    ('stamen', 'terrain') : (
-        'Map tiles by <a href="https://stamen.com">Stamen Design</a>, '
-        'under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. '
-        'Data by <a href="https://openstreetmap.org">OpenStreetMap</a>, '
-        'under <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.'
-    ),
-    ('stamen', 'toner') : (
+    ('stamen', 'com/t') : ( # to match both 'toner' and 'terrain'
         'Map tiles by <a href="https://stamen.com">Stamen Design</a>, '
         'under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. '
         'Data by <a href="https://openstreetmap.org">OpenStreetMap</a>, '
         'under <a href="https://www.openstreetmap.org/copyright">ODbL</a>.'
+    ),
+    ('stamen', 'watercolor') : (
+        'Map tiles by <a href="https://stamen.com">Stamen Design</a>, '
+        'under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. '
+        'Data by <a href="https://openstreetmap.org">OpenStreetMap</a>, '
+        'under <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.'
     ),
     ('wikimedia',) : (
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -59,7 +59,7 @@ CartoMidnight = WMTS('http://3.api.cartocdn.com/base-midnight/{Z}/{X}/{Y}.png')
 # Stamen basemaps
 StamenTerrain = WMTS('http://tile.stamen.com/terrain/{Z}/{X}/{Y}.png')
 StamenTerrainRetina = WMTS('http://tile.stamen.com/terrain/{Z}/{X}/{Y}@2x.png')
-StamenWatercolor = WMTS('http://c.tile.stamen.com/watercolor/{Z}/{X}/{Y}.jpg')
+StamenWatercolor = WMTS('http://tile.stamen.com/watercolor/{Z}/{X}/{Y}.jpg')
 StamenToner = WMTS('http://tile.stamen.com/toner/{Z}/{X}/{Y}.png')
 StamenTonerBackground = WMTS('http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png')
 StamenLabels = WMTS('http://tile.stamen.com/toner-labels/{Z}/{X}/{Y}.png')
@@ -78,4 +78,4 @@ OSM = WMTS('http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png')
 Wikipedia = WMTS('https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png')
 
 
-tile_sources = {k: v for k, v in locals().items() if isinstance(v, WMTS)}
+tile_sources = {k: v for k, v in locals().items() if isinstance(v, WMTS) and k != 'ESRI'}


### PR DESCRIPTION
* Replaced "ESRI" with "EsriImagery" in examples
* Removed "ESRI" from the list of default tile sources
* Fixed missing attribution for Stamen Watercolor and incorrect attribution for Stamen Terrain (based on current advice from [Stamen](http://maps.stamen.com/#howto))
* Removed confusing statement in docs that made it seem like the Matplotlib backend did not support web tile servers