### PR TITLE
Removed references to non-existent notebooks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,6 @@ jobs:
         - pip install git+https://github.com/pyviz/nbsite.git
         - geoviews fetch-data --path=examples
         - bokeh sampledata
-        - rm examples/Colocated_cube_pair.ipynb examples/CubeExplorer_Prototype.ipynb # not currently part of website
         # note: will vastly simplified in a future version of nbsite
         - cd doc
         - nbsite_nbpagebuild.py ioam geoviews ../examples .

--- a/tox.ini
+++ b/tox.ini
@@ -67,8 +67,6 @@ addopts = -v --pyargs --doctest-modules --doctest-ignore-import-errors
 norecursedirs = doc .git dist build _build .ipynb_checkpoints
 # depend on optional iris, xesmf, etc
 nbsmoke_skip_run = .*Homepage\.ipynb$
-                   .*Colocated_cube_pair\.ipynb$
-                   .*CubeExplorer_Prototype\.ipynb$
                    .*user_guide/Resampling_Grids\.ipynb$
                    .*user_guide/Gridded_Datasets_.*\.ipynb$
                    .*gallery/bokeh/xarray_gridded\.ipynb$


### PR DESCRIPTION
The `rm ...` in travis is why the doc build failed for the last tag push.

This reminds me...I can't remember if the doc build for geoviews is doing what you want now:
  * push dev tag: updates https://ioam-docs.github.io/geoviews-dev/
  * push release tag: updates https://ioam-docs.github.io/geoviews-release/

You could build the docs locally, too, if you were working on the docs specifically `(*)`. (Could also set it up so pushing a special tag, e.g. 'doc-build' or whatever, updates another site e.g. https://ioam-docs.github.io/geoviews-tmp/ or something like that.)

`(*)` Not quite there yet, but there will be a simple nbsite command to run locally for that soon, I hope. But for the purposes of deciding if the options cover what you want, please pretend it exists.

