### PR TITLE
Packaging fixups

### DIFF
--- a/conda.recipe/core/meta.yaml
+++ b/conda.recipe/core/meta.yaml
@@ -18,6 +18,8 @@ build:
     {% endfor %}
 
 requirements:
+  run_constrained:
+    - geoviews {{ version }}
   build:
     - python {{ sdata['python_requires'] }}
     {% for dep in sdata['extras_require']['build'] %}

--- a/conda.recipe/core/meta.yaml
+++ b/conda.recipe/core/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   run_constrained:
     - geoviews {{ version }}
-  build:
+  host:
     - python {{ sdata['python_requires'] }}
     {% for dep in sdata['extras_require']['build'] %}
     - {{ dep }}

--- a/conda.recipe/recommended/meta.yaml
+++ b/conda.recipe/recommended/meta.yaml
@@ -11,7 +11,7 @@ build:
   noarch: python
 
 requirements:
-  build:
+  host:
     - python {{ sdata['python_requires'] }}
     {% for dep in sdata['extras_require']['build'] %}
     - {{ dep }}


### PR DESCRIPTION
* Prevent installation of old (pre-split) geoviews alongside geoviews-core.
* Switch from host to build (equivalent when there's no building, but host is recommended).